### PR TITLE
Fix sidebar close animation flicker on mobile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,88 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with
+code in this repository.
+
+## Project Overview
+
+This is Jimmy Van Veen's portfolio website built with React Router v7, featuring
+a blog powered by Contentful CMS and GitHub API integration for project data.
+
+## Development Commands
+
+```bash
+# Start development server (custom Express + Vite)
+npm run dev
+
+# Build for production
+npm run build
+
+# Type generation and checking
+npm run typecheck
+
+# Start local Netlify server
+npm start
+```
+
+## Architecture
+
+### Tech Stack
+
+- **React Router v7** with SSR enabled
+- **React 19** with TypeScript strict mode
+- **Tailwind CSS v4** with shadcn/ui components
+- **Vite** for building and development
+- **Contentful** for blog CMS
+- **GitHub API** via Octokit for repository data
+
+### Key Structure
+
+- `app/root.tsx` - Application shell with sidebar provider
+- `app/routes.ts` - Route configuration (file-based routing)
+- `app/utils/` - API integrations (Contentful, GitHub, email)
+- `app/components/ui/` - shadcn/ui component library
+- `server/app.ts` - Netlify Functions entry point
+
+### Data Flow
+
+- Route loaders fetch data from Contentful CMS and GitHub API
+- Type-safe data consumption throughout the app
+- Suspense boundaries for loading states
+- Error boundaries for graceful failures
+
+## Environment Variables
+
+Prefix custom environment variables with `JVV_`:
+
+- `CONTENTFUL_SPACE_ID` - Contentful space
+- `CONTENTFUL_ACCESS_TOKEN` - Contentful API token
+- `GITHUB_TOKEN` - GitHub API token
+- Email service configuration
+
+## Key Patterns
+
+### Component Organization
+
+- UI components follow shadcn/ui patterns with Radix primitives
+- Responsive sidebar layout with mobile collapse
+- CSS Grid for project displays
+- Path alias `~/*` maps to `app/` directory
+
+### Content Management
+
+- Blog posts managed via Contentful with rich text rendering
+- GitHub repositories filtered by Node ID in `github.ts:88`
+- Project metadata stored in Contentful, code data from GitHub API
+
+### Deployment
+
+- Netlify hosting with custom preparation script
+- SSR via Netlify Functions
+- Build process includes React Router typegen
+
+## Notable Implementation Details
+
+- Custom dev server at `dev-server.js` wraps Vite with Express
+- Blog header includes animated marquee of recent posts
+- Rate limiting and retry logic in GitHub API integration
+- Type generation runs automatically during builds

--- a/app/components/app-sidebar/app-sidebar.tsx
+++ b/app/components/app-sidebar/app-sidebar.tsx
@@ -6,6 +6,7 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  useSidebar,
 } from "~/components/ui/sidebar"
 
 import * as React from "react"
@@ -16,6 +17,14 @@ import logo from "~/components/app-sidebar/jimmyvanveen.svg?url"
 import { href, Link } from "react-router"
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
+  const { setOpenMobile, isMobile } = useSidebar()
+
+  const handleLinkClick = () => {
+    if (isMobile) {
+      setOpenMobile(false)
+    }
+  }
+
   return (
     <Sidebar
       className="top-[var(--header-height)] !h-[calc(100svh-var(--header-height))] bg-[var(--sidebar-background)]"
@@ -26,7 +35,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         <SidebarMenu>
           <SidebarMenuItem>
             <SidebarMenuButton size="xl" asChild className="mb-3">
-              <Link to={href("/")}>
+              <Link to={href("/")} onClick={handleLinkClick}>
                 <div className="flex aspect-square size-16 items-center justify-center rounded-lg bg-sidebar-primary text-sidebar-primary-foreground">
                   <img src={logo} alt="Jimmy Van Veen" />
                 </div>
@@ -48,6 +57,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         </div>
         <Link
           to={href("/blog")}
+          onClick={handleLinkClick}
           className="bg-accent-foreground hover:bg-accent hover:text-accent-foreground font-bold py-4 px-6 rounded-xl"
         >
           Jimmy's Blog

--- a/app/components/ui/sheet.tsx
+++ b/app/components/ui/sheet.tsx
@@ -34,7 +34,9 @@ function SheetOverlay({
     <SheetPrimitive.Overlay
       data-slot="sheet-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/80",
+        "fixed inset-0 z-50 bg-black/80",
+        "data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:duration-500",
+        "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:duration-300",
         className
       )}
       {...props}
@@ -56,7 +58,9 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          "bg-background fixed z-50 flex flex-col gap-4 shadow-lg overflow-hidden",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out",
+          "data-[state=open]:duration-500 data-[state=closed]:duration-300",
           side === "right" &&
             "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
           side === "left" &&

--- a/app/components/ui/sidebar.tsx
+++ b/app/components/ui/sidebar.tsx
@@ -382,12 +382,15 @@ function SidebarSeparator({
 }
 
 function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
+  const { isMobile } = useSidebar()
+  
   return (
     <div
       data-slot="sidebar-content"
       data-sidebar="content"
       className={cn(
-        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto",
+        "group-data-[collapsible=icon]:overflow-hidden",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- Fixed the visual flicker that occurred when closing the mobile sidebar
- Sidebar now closes properly when clicking on navigation links

## Changes
- Added `handleLinkClick` function to close sidebar on mobile when navigation links are clicked
- Fixed overlay animation flicker by synchronizing durations between overlay and content
- Ensured proper overflow handling during slide transitions
- Matched animation timings: 500ms for opening, 300ms for closing

## Test plan
- [x] Open site on mobile device or responsive view
- [x] Open the sidebar menu
- [x] Click on any navigation link (e.g., "Jimmy's Blog")
- [x] Verify sidebar closes smoothly without overlay flicker
- [x] Verify no content overflow during the transition