### PR TITLE
docs(readme): fix devDependency badges, add last-commit + react-router

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 [![Netlify Status](https://api.netlify.com/api/v1/badges/1fb9ad3c-9c4b-4783-9ef8-7af1eb3daf8d/deploy-status)](https://app.netlify.com/sites/jimmyvanveencom/deploys)
 ![React](https://img.shields.io/github/package-json/dependency-version/JimmayVV/JimmyVanVeen.com/react?style=flat&logo=react&logoColor=white)
-![TypeScript](https://img.shields.io/github/package-json/dependency-version/JimmayVV/JimmyVanVeen.com/typescript?style=flat&logo=typescript&logoColor=white)
-![Tailwind CSS](https://img.shields.io/github/package-json/dependency-version/JimmayVV/JimmyVanVeen.com/tailwindcss?style=flat&logo=tailwindcss&logoColor=white)
+![TypeScript](https://img.shields.io/github/package-json/dependency-version/JimmayVV/JimmyVanVeen.com/dev/typescript?style=flat&logo=typescript&logoColor=white)
+![Tailwind CSS](https://img.shields.io/github/package-json/dependency-version/JimmayVV/JimmyVanVeen.com/dev/tailwindcss?style=flat&logo=tailwindcss&logoColor=white)
 [![Website](https://img.shields.io/website?url=https%3A%2F%2Fwww.jimmyvanveen.com&style=flat)](https://www.jimmyvanveen.com)
 [![GitHub Issues](https://img.shields.io/github/issues/JimmayVV/JimmyVanVeen.com?style=flat)](https://github.com/JimmayVV/JimmyVanVeen.com/issues)
 [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/JimmayVV/JimmyVanVeen.com?style=flat)](https://github.com/JimmayVV/JimmyVanVeen.com/commits/main)
+[![Last commit](https://img.shields.io/github/last-commit/JimmayVV/JimmyVanVeen.com?style=flat)](https://github.com/JimmayVV/JimmyVanVeen.com/commits/main)
+![React Router](https://img.shields.io/github/package-json/dependency-version/JimmayVV/JimmyVanVeen.com/react-router?style=flat&logo=reactrouter&logoColor=white&label=react-router)
 
 # Jimmy Van Veen's Portfolio
 


### PR DESCRIPTION
## Summary
- Fix TypeScript and Tailwind badges that were rendering "prod dependency not found" — both are devDependencies, so the shields.io URL needed the `/dev/` path segment.
- Add a **last-commit** badge to signal the repo is alive.
- Add a **react-router** badge since v7 is the headline framework and wasn't represented.

## Test plan
- [x] Confirmed TypeScript and Tailwind are devDependencies in package.json (correct placement — both are build-time only)
- [ ] Visually verify all badges render once Netlify preview / GitHub renders the README