### PR TITLE
feat(site): cohesive editorial pass — TopBar, home cover, Newsreader

### DIFF
--- a/Plans/cohesive-site-editorial-pass.md
+++ b/Plans/cohesive-site-editorial-pass.md
@@ -1,0 +1,200 @@
+# Cohesive Site Editorial Pass — Round 2
+
+## Context
+
+PR #303 redesigned the blog as a typography-first reading experience. Reviewing the deploy preview, two things are clear:
+
+1. The **rest of the site doesn't match**. The home page (mission statement on a racing-photo background + dark project cards + persistent left sidebar) feels like a different application from the blog. The contrast highlights how generic the home actually is.
+2. Inside the blog itself, the **Fraunces ampersand** in "Notes & field reports." reads as ugly — Fraunces' default `&` is one of its most polarizing glyphs. Headlines should switch to a more restrained editorial face. Pull quotes and drop cap can keep Fraunces, where its character is an asset.
+
+Goal: make the **whole site feel like one publication** — same palette, same type voice, same chrome, same theme toggle behavior. Add a hero photograph treatment to the home page (editorial-grade, not background-image-y), allow photographs sparingly elsewhere as "plates," and replace the existing sidebar with the slim top bar already proven on the blog.
+
+This is a separate, second PR on top of (or after merging) `feature/blog-editorial-redesign`. Branch: `feature/cohesive-editorial-pass`.
+
+---
+
+## Decisions (locked from your answers)
+
+| Question | Decision |
+|---|---|
+| Home concept | Editorial + hero photo |
+| Sidebar | Replace with slim top bar site-wide |
+| Photographs | Sparingly, treated as plates |
+| Display face | Switch headlines to **Newsreader** (Fraunces only for italic pull quotes + drop cap) |
+
+---
+
+## Type system — revised
+
+| Role | Family | Notes |
+|---|---|---|
+| Display (all H1, index intro, brand) | **Newsreader** (variable: `wght`, `opsz`, italic) | Restrained editorial serif, well-drawn `&`, true `opsz` axis. Replaces Fraunces for headlines. |
+| Body | **Source Serif 4** | Unchanged. |
+| Italic accent (pull quotes, drop cap) | **Fraunces** italic 72/144 opsz | Kept only where its character earns it. Not used for headlines, not used in the brand. |
+| Mono | **JetBrains Mono** | Unchanged. |
+
+Action: add Newsreader to the Google Fonts URL in [app/root.tsx](app/root.tsx). Add `--font-newsreader` token in [app/app.css](app/app.css). Update `.blog-post-hero h1`, `.blog-index-intro`, `.blog-index-row .title`, and `.prose-editorial h2/h3` to use Newsreader. Keep `.prose-editorial blockquote` and the drop cap on Fraunces.
+
+---
+
+## Site chrome — slim top bar everywhere
+
+Currently the sidebar lives in [app/root.tsx](app/root.tsx) `Template`, except blog routes which I bypassed in PR #303. New approach: **remove the sidebar entirely**. Every page renders inside the same shell:
+
+```
+┌─ blog-topbar (sticky, hairline-bottom) ─────────────────┐
+│  ← JIMMY VAN VEEN     Home · Projects · Blog       ☀  │
+├──────────────────────────────────────────────────────────┤
+│                                                          │
+│            [reading column / page content]               │
+│                                                          │
+└──────────────────────────────────────────────────────────┘
+```
+
+- **Brand** (left): `← JIMMY VAN VEEN` in mono uppercase. On `/` it's just `JIMMY VAN VEEN` (no arrow, since you're already home).
+- **Section nav** (center or left-aligned next to brand on desktop, hamburger sheet on mobile): three links — **Home**, **Projects**, **Blog** — in mono small caps. Active route gets accent underline.
+- **Theme toggle** (right): same `<ThemeToggle>` already built. Now lives in the global top bar, available everywhere.
+
+The existing `<AppSidebar>`, `<AppHeader>`, `<SidebarInset>`, and `<SidebarProvider>` get removed from `Template`. The blog layout's local top bar gets replaced by this global one. The sidebar plumbing in shadcn (`app/components/ui/sidebar.tsx`) stays in the codebase for now (low risk to leave it; a separate cleanup PR can delete it if you want).
+
+Files touched:
+- [app/root.tsx](app/root.tsx) — strip sidebar shell from `Template`, mount global top bar
+- [app/routes/blog/layout.tsx](app/routes/blog/layout.tsx) — drop the local top bar (replaced by global)
+- New: `app/components/site/top-bar.tsx` — the shared component, with section nav + theme toggle
+- Existing `app/components/app-header.tsx`, `app/components/app-sidebar/*`, `app/components/header.tsx` — stop being mounted; left in place for now (don't delete in this PR — keeps the diff focused on what's visible)
+
+---
+
+## Site-wide theme (extending `.blog-theme`)
+
+Currently `.blog-theme` is scoped to the blog. For cohesion, the editorial palette becomes the **site palette**. Two paths:
+
+**Chosen path**: rename `.blog-theme` → `.editorial-theme` and apply it on `<html>` (or the top-level shell `<div>`). All pages get the paper/midnight-ink palette and the editorial fonts by default. The legacy `--background` / `--foreground` tokens stay so any unmigrated component still renders, but the default surface for every page becomes paper / midnight ink.
+
+The home, projects, and blog all read from the same set of CSS variables. The theme toggle works everywhere because it sets `.dark` on `<html>` (already does).
+
+---
+
+## Home page — "Cover"
+
+Replaces the current `mission-statement on racing photo + project cards` layout.
+
+**Above the fold (desktop)**:
+- Mono dateline: `JIMMY VAN VEEN · ENGINEER · DETROIT` (or whatever you want — placeholder copy you can edit)
+- H1 in Newsreader, large: a single editorial line (e.g. *"I build software for the long form."* — placeholder, you tune the copy)
+- Italic Source Serif 4 dek (1–2 lines)
+- Hero photograph (the **plate**): single full-width-of-column image, treated editorially
+  - Available on the right-hand side at desktop ≥1100px (asymmetric magazine layout) OR below the title at narrower widths
+  - Subtle warm overlay / desaturation so it sits with the palette instead of fighting it
+  - Caption beneath: small mono, e.g. `Plate I — Talladega, 2024`
+  - **Source for the photo**: I'll use one of the existing images in [public/images/](public/images/) (talladega_glory.jpg is the one already in your CSS). Open question for you to answer in the PR review: which photo do you actually want here? I'll start with `talladega_glory.jpg` desaturated.
+
+**Below the fold**:
+1. **Section: "Recent writing"** — the same editorial list component the blog index uses, showing 3 most-recent posts. "All posts →" link at the bottom.
+2. **Hairline rule** with `❦` ornament (already defined for `<hr>` in `.prose-editorial`).
+3. **Section: "Selected work"** — projects rendered as editorial rows (not the dark cards). Title (Newsreader) + one-line dek + small mono link → live demo / source. 2–3 items, hand-picked. Eventually a "All projects →" link points to a redesigned `/projects`.
+4. **Footer** — small mono links: GitHub, Bluesky, email. Hairline above.
+
+This kills:
+- `app/components/banner.tsx` (racing photo background as a hero pattern)
+- `app/components/mission.tsx` and the all-caps mission statement block
+- `app/components/content-cards.tsx` usage on home (the dark cards)
+
+The components stay in the codebase but stop being rendered on home. Same minimal-blast-radius rule as the sidebar.
+
+---
+
+## Projects page
+
+Currently `/projects` is rendered through the same dark-card pattern. Editorial pass:
+- Same top bar
+- Page title in Newsreader: `Projects.`
+- Italic dek
+- Hairline rule
+- Each project = an editorial row (title, dek, mono links). Optional plate (project screenshot) per row, sparingly.
+- Source data still comes from Contentful + GitHub via the existing utils — only the rendering changes.
+
+For this PR I'll do projects in the **same shape as the home's "Selected work" section** — a single shared `<ProjectRow>` component used in both places. That keeps the abstraction tight.
+
+---
+
+## Photograph plate component
+
+New: `app/components/site/plate.tsx`
+
+```
+<Plate src="..." alt="..." caption="Plate I — Talladega, 2024" credit?="..." />
+```
+
+Renders:
+- A `<figure>` with the image, a hairline border in the rule color
+- Subtle CSS treatment: `filter: saturate(0.85) contrast(1.02);` and a 1px inner border in `--blog-rule` for a printed feel. No drop shadow (those scream "PowerPoint").
+- Caption in mono, `--blog-muted`, centered.
+
+Used in:
+- Home hero
+- Inside blog posts when the markdown contains an image (override `react-markdown` `img` component to render through `<Plate>` when `alt` text is present)
+- Optionally on project rows
+
+---
+
+## Theme toggle scope
+
+Already global (sets `.dark` on `<html>`), already persists in `localStorage`. The change is just **where it's mounted**: instead of only being in the blog layout, it lives in the global top bar. Done by moving `<ThemeToggle>` into `<TopBar>` and removing it from `BlogLayout`.
+
+---
+
+## Files to change
+
+### New
+- `app/components/site/top-bar.tsx` — site-wide chrome (brand, section nav, theme toggle)
+- `app/components/site/plate.tsx` — photograph treatment
+- `app/components/site/project-row.tsx` — editorial project row (used on home + projects page)
+
+### Modified
+- [app/root.tsx](app/root.tsx) — load Newsreader; strip sidebar shell from `Template`; mount `<TopBar>`; apply `.editorial-theme` class on the wrapper
+- [app/app.css](app/app.css) — add `--font-newsreader`; rename `.blog-theme` → `.editorial-theme` (or alias both); swap headline rules to Newsreader; add `<Plate>` styles, `<ProjectRow>` styles, top-bar nav-link styles (active state, hover)
+- [app/routes/blog/layout.tsx](app/routes/blog/layout.tsx) — drop local top bar, just renders `<Outlet />` inside the `.editorial-theme` (or remove the wrapper since root provides it)
+- [app/routes/blog/blog-index.tsx](app/routes/blog/blog-index.tsx) — fonts pick up Newsreader automatically; verify spacing
+- [app/routes/blog/$slug.tsx](app/routes/blog/$slug.tsx) — override `react-markdown` `img` component → `<Plate>` when alt text present
+- The home route file (need to read to confirm path — likely `app/routes/_index.tsx` or `app/routes/home.tsx`) — full rewrite to the cover layout
+- The projects route file — replace dark cards with `<ProjectRow>` list
+
+### Reused (no change)
+- `<ThemeToggle>`, `<ReadingProgress>`, `<PostHero>`, `<PostFooter>` — already work
+- `app/utils/contentful*`, `app/utils/github*` — data layer untouched
+- `public/theme-init.js` — already global
+
+### Stops being rendered (left in codebase)
+- `app/components/app-header.tsx`, `app/components/app-sidebar/*`, `app/components/header.tsx`, `app/components/banner.tsx`, `app/components/mission.tsx`, `app/components/content-cards.tsx`, `app/components/gradient-banner.tsx`, `app/components/ui/sidebar.tsx`. Cleanup is a separate PR if you want it.
+
+---
+
+## Open questions for you
+
+1. **Hero photo**: which image should I use as the home plate? Defaulting to `public/images/talladega_glory.jpg` (already in repo) desaturated. If you have a better one, drop a path.
+2. **Home title copy**: I'll put a placeholder you can edit. Do you have a single line you want there, or want me to draft three options in the PR description for you to pick?
+3. **Section nav order in top bar**: `Home · Projects · Blog` — sound right?
+4. **Mobile top bar**: hamburger sheet vs. inline nav at small sizes? Default: inline (just brand + theme toggle, hide section nav under a small "≡ Menu" sheet under 640px).
+
+---
+
+## Verification
+
+1. `npm run dev`. Visit `/`, `/projects`, `/blog`, `/blog/<slug>`. Every page has the same top bar, same palette, same fonts. The theme toggle is in the top bar everywhere. Toggling persists across navigation.
+2. The Fraunces `&` no longer appears in any headline. Spot-check the blog index intro renders with Newsreader.
+3. Home hero plate renders desaturated, with caption, and reflows below the title at <1100px.
+4. Mobile (375px): top bar collapses cleanly; hero plate stacks under the title; recent writing section reads as the editorial list.
+5. `npm run lint`, `npm run typecheck`, `npm run build` all clean.
+6. Visit a blog post. If the post body contains an image, it renders through `<Plate>` with a caption from the alt text.
+7. Sit with each page in both light and dark modes for 30 seconds. Does it feel like one publication? That's the actual test.
+
+---
+
+## Out of scope (deferred)
+
+- Deleting the unused sidebar/banner/mission components (separate PR; leaves diff focused)
+- Redesigning individual project cards (we render them as editorial rows; existing card components stay unrendered)
+- Rewriting Contentful fetch logic
+- Photography curation / new images — using existing `public/images/*`
+- Fancier mobile nav (drawer/sheet animation) — defaulting to a simple inline sheet

--- a/app/app.css
+++ b/app/app.css
@@ -15,8 +15,10 @@
   --font-sans: "Source Sans 3", helvetica, sans-serif;
   --font-raleway: Raleway, helvetica, sans-serif;
 
-  /* Editorial blog typography */
-  --font-display: Fraunces, "Times New Roman", Georgia, serif;
+  /* Editorial typography (site-wide) */
+  --font-display:
+    Newsreader, "Iowan Old Style", "Palatino Linotype", Georgia, serif;
+  --font-display-italic: Fraunces, Newsreader, Georgia, serif;
   --font-serif:
     "Source Serif 4", "Iowan Old Style", "Palatino Linotype", Georgia, serif;
   --font-mono: "JetBrains Mono", "SF Mono", "Cascadia Mono", Menlo, monospace;
@@ -285,6 +287,7 @@ a[target="_blank"]:not(#sidebar-footer a)::after {
    Typography-first reading experience. Two true themes: paper / midnight ink.
    ─────────────────────────────────────────────────────────────────────────── */
 
+.editorial-theme,
 .blog-theme {
   /* paper (light) */
   --paper-bg: #f7f4ec;
@@ -322,7 +325,8 @@ a[target="_blank"]:not(#sidebar-footer a)::after {
   min-height: 100vh;
 }
 
-.dark .blog-theme {
+.dark .editorial-theme,
+.blog-theme {
   /* midnight ink (dark) */
   --blog-bg: #13110f;
   --blog-surface: #1c1916;
@@ -438,11 +442,11 @@ a[target="_blank"]:not(#sidebar-footer a)::after {
 
 .blog-index-intro {
   font-family: var(--font-display);
-  font-variation-settings: "opsz" 144;
+  font-variation-settings: "opsz" 60;
   font-weight: 500;
   font-size: clamp(2rem, 4.5vw, 3rem);
   line-height: 1.05;
-  letter-spacing: -0.02em;
+  letter-spacing: -0.018em;
   color: var(--blog-ink);
   margin-bottom: 0.5rem;
   text-wrap: balance;
@@ -489,7 +493,7 @@ a[target="_blank"]:not(#sidebar-footer a)::after {
 }
 .blog-index-row .title {
   font-family: var(--font-display);
-  font-variation-settings: "opsz" 96;
+  font-variation-settings: "opsz" 48;
   font-weight: 500;
   font-size: 1.875rem;
   line-height: 1.15;
@@ -548,11 +552,11 @@ a[target="_blank"]:not(#sidebar-footer a)::after {
 }
 .blog-post-hero h1 {
   font-family: var(--font-display);
-  font-variation-settings: "opsz" 144;
+  font-variation-settings: "opsz" 72;
   font-weight: 600;
   font-size: clamp(2.4rem, 5vw, 3.8rem);
   line-height: 1.05;
-  letter-spacing: -0.022em;
+  letter-spacing: -0.02em;
   color: var(--blog-ink);
   margin-bottom: 1.25rem;
   text-wrap: balance;
@@ -629,7 +633,7 @@ a[target="_blank"]:not(#sidebar-footer a)::after {
   font-weight: 600;
   font-size: 1.75rem;
   line-height: 1.2;
-  letter-spacing: -0.012em;
+  letter-spacing: -0.01em;
   color: var(--blog-ink);
   margin-top: 2.5em;
   margin-bottom: 0.6em;
@@ -813,9 +817,9 @@ a[target="_blank"]:not(#sidebar-footer a)::after {
   user-select: none;
 }
 
-/* Drop cap on long posts */
+/* Drop cap on long posts — kept on Fraunces, the one place its character earns it */
 .prose-editorial[data-long="true"] > p:first-of-type::first-letter {
-  font-family: var(--font-display);
+  font-family: var(--font-display-italic);
   font-variation-settings: "opsz" 144;
   font-weight: 700;
   float: left;
@@ -886,4 +890,360 @@ a[target="_blank"]:not(#sidebar-footer a)::after {
     width: 100%;
     animation: none;
   }
+}
+
+/* ───────────────────────────────────────────────────────────────────────────
+   Site chrome — TopBar (replaces sidebar)
+   ─────────────────────────────────────────────────────────────────────────── */
+
+.site-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  padding: 0.875rem clamp(1.25rem, 5vw, 3rem);
+  background: color-mix(in srgb, var(--blog-bg) 92%, transparent);
+  backdrop-filter: saturate(160%) blur(8px);
+  -webkit-backdrop-filter: saturate(160%) blur(8px);
+  border-bottom: 1px solid var(--blog-rule);
+}
+
+.site-topbar .brand {
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--blog-ink);
+  text-decoration: none;
+  transition: color 200ms ease;
+  white-space: nowrap;
+}
+.site-topbar .brand:hover {
+  color: var(--blog-accent);
+}
+
+.site-topbar nav.section-nav {
+  display: none;
+  gap: 1.5rem;
+  margin-left: 2rem;
+}
+@media (min-width: 720px) {
+  .site-topbar nav.section-nav {
+    display: flex;
+  }
+}
+
+.site-topbar nav.section-nav a {
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--blog-muted);
+  text-decoration: none;
+  padding: 0.25rem 0;
+  border-bottom: 1px solid transparent;
+  transition:
+    color 180ms ease,
+    border-color 180ms ease;
+}
+.site-topbar nav.section-nav a:hover {
+  color: var(--blog-ink);
+}
+.site-topbar nav.section-nav a[aria-current="page"] {
+  color: var(--blog-accent);
+  border-bottom-color: var(--blog-accent);
+}
+
+.site-topbar .spacer {
+  flex: 1;
+}
+
+/* Mobile menu — small inline sheet under 720px */
+.site-topbar .menu-button {
+  display: inline-flex;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--blog-muted);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+}
+.site-topbar .menu-button:hover {
+  color: var(--blog-ink);
+}
+@media (min-width: 720px) {
+  .site-topbar .menu-button {
+    display: none;
+  }
+}
+
+.site-mobile-sheet {
+  position: fixed;
+  inset: 56px 0 auto 0;
+  z-index: 29;
+  background: var(--blog-bg);
+  border-bottom: 1px solid var(--blog-rule);
+  padding: 1rem clamp(1.25rem, 5vw, 3rem) 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+.site-mobile-sheet a {
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--blog-muted);
+  text-decoration: none;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--blog-rule);
+}
+.site-mobile-sheet a[aria-current="page"] {
+  color: var(--blog-accent);
+}
+
+/* ───────────────────────────────────────────────────────────────────────────
+   Plate — editorial photograph treatment (sparing, deliberate)
+   ─────────────────────────────────────────────────────────────────────────── */
+
+.plate {
+  margin: 0;
+  display: block;
+}
+.plate-frame {
+  position: relative;
+  overflow: hidden;
+  border-radius: 2px;
+  background: var(--blog-surface);
+  box-shadow:
+    inset 0 0 0 1px var(--blog-rule),
+    0 1px 0 0 color-mix(in srgb, var(--blog-rule) 60%, transparent);
+}
+.plate-frame img {
+  display: block;
+  width: 100%;
+  height: auto;
+  filter: saturate(0.78) contrast(1.04);
+  transition: filter 600ms ease;
+}
+.dark .plate-frame img {
+  filter: saturate(0.7) contrast(1.05) brightness(0.92);
+}
+.plate-caption {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--blog-muted);
+  margin-top: 0.875rem;
+  text-align: center;
+}
+.plate-caption .credit {
+  text-transform: none;
+  letter-spacing: 0.04em;
+  color: color-mix(in srgb, var(--blog-muted) 70%, transparent);
+}
+
+/* ───────────────────────────────────────────────────────────────────────────
+   Home cover
+   ─────────────────────────────────────────────────────────────────────────── */
+
+.home-cover {
+  max-width: 72ch;
+  margin: 0 auto;
+  padding: clamp(2rem, 5vw, 4rem) clamp(1.25rem, 5vw, 3rem)
+    clamp(3rem, 8vw, 6rem);
+}
+
+.home-dateline {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--blog-muted);
+  margin-bottom: 1.5rem;
+}
+
+.home-title {
+  font-family: var(--font-display);
+  font-variation-settings: "opsz" 72;
+  font-weight: 500;
+  font-size: clamp(2.5rem, 6vw, 4.25rem);
+  line-height: 1.02;
+  letter-spacing: -0.022em;
+  color: var(--blog-ink);
+  margin-bottom: 1rem;
+  text-wrap: balance;
+}
+
+.home-dek {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: 1.25rem;
+  line-height: 1.5;
+  color: var(--blog-muted);
+  margin-bottom: 2.5rem;
+  max-width: 52ch;
+  text-wrap: pretty;
+}
+
+.home-hero-plate {
+  margin: 2rem 0 3.5rem;
+}
+
+@media (min-width: 1100px) {
+  .home-cover {
+    max-width: none;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1.05fr);
+    grid-template-areas:
+      "text plate"
+      "sections sections";
+    column-gap: clamp(2rem, 5vw, 4rem);
+    row-gap: 4rem;
+    padding-left: clamp(2rem, 6vw, 5rem);
+    padding-right: clamp(2rem, 6vw, 5rem);
+  }
+  .home-cover > .home-text {
+    grid-area: text;
+    align-self: end;
+    max-width: 28em;
+  }
+  .home-cover > .home-hero-plate {
+    grid-area: plate;
+    align-self: end;
+    margin: 0;
+  }
+  .home-cover > .home-sections {
+    grid-area: sections;
+    max-width: 72ch;
+    margin: 0 auto;
+    width: 100%;
+  }
+}
+
+.home-section {
+  margin-top: 3.5rem;
+}
+.home-section .head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+  padding-bottom: 0.875rem;
+  border-bottom: 1px solid var(--blog-rule);
+}
+.home-section .head h2 {
+  font-family: var(--font-display);
+  font-variation-settings: "opsz" 36;
+  font-weight: 500;
+  font-size: 1.5rem;
+  letter-spacing: -0.012em;
+  color: var(--blog-ink);
+  margin: 0;
+}
+.home-section .head a.see-all {
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--blog-accent);
+  text-decoration: none;
+}
+.home-section .head a.see-all:hover {
+  color: var(--blog-accent-soft);
+}
+
+/* ───────────────────────────────────────────────────────────────────────────
+   ProjectRow — editorial project list item
+   ─────────────────────────────────────────────────────────────────────────── */
+
+.project-row {
+  padding: 1.5rem 0;
+  border-bottom: 1px solid var(--blog-rule);
+}
+.project-row:last-child {
+  border-bottom: none;
+}
+.project-row .row-title {
+  font-family: var(--font-display);
+  font-variation-settings: "opsz" 36;
+  font-weight: 500;
+  font-size: 1.5rem;
+  line-height: 1.15;
+  letter-spacing: -0.01em;
+  color: var(--blog-ink);
+  margin-bottom: 0.4rem;
+}
+.project-row .row-dek {
+  font-family: var(--font-serif);
+  font-size: 1.0625rem;
+  line-height: 1.5;
+  color: var(--blog-muted);
+  margin-bottom: 0.75rem;
+  max-width: 56ch;
+}
+.project-row .row-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  font-family: var(--font-mono);
+  font-size: 0.74rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+.project-row .row-links a {
+  color: var(--blog-accent);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 180ms ease;
+}
+.project-row .row-links a:hover {
+  border-bottom-color: var(--blog-accent);
+}
+
+/* ───────────────────────────────────────────────────────────────────────────
+   Site footer
+   ─────────────────────────────────────────────────────────────────────────── */
+
+.site-footer {
+  max-width: 72ch;
+  margin: 4rem auto 0;
+  padding: 2rem clamp(1.25rem, 5vw, 3rem) 3rem;
+  border-top: 1px solid var(--blog-rule);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  justify-content: space-between;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--blog-muted);
+}
+.site-footer a {
+  color: var(--blog-muted);
+  text-decoration: none;
+  transition: color 180ms ease;
+}
+.site-footer a:hover {
+  color: var(--blog-accent);
+}
+.site-footer .footer-links {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
 }

--- a/app/components/site/plate.tsx
+++ b/app/components/site/plate.tsx
@@ -1,0 +1,24 @@
+interface PlateProps {
+  src: string;
+  alt: string;
+  caption?: string;
+  credit?: string;
+  className?: string;
+}
+
+export function Plate({ src, alt, caption, credit, className }: PlateProps) {
+  return (
+    <figure className={`plate${className ? ` ${className}` : ""}`}>
+      <div className="plate-frame">
+        <img src={src} alt={alt} loading="lazy" decoding="async" />
+      </div>
+      {caption || credit ? (
+        <figcaption className="plate-caption">
+          {caption}
+          {caption && credit ? "  " : null}
+          {credit ? <span className="credit">— {credit}</span> : null}
+        </figcaption>
+      ) : null}
+    </figure>
+  );
+}

--- a/app/components/site/project-row.tsx
+++ b/app/components/site/project-row.tsx
@@ -1,0 +1,32 @@
+interface ProjectRowProps {
+  title: string;
+  description?: string | null;
+  liveUrl?: string | null;
+  repoUrl?: string;
+}
+
+export function ProjectRow({
+  title,
+  description,
+  liveUrl,
+  repoUrl,
+}: ProjectRowProps) {
+  return (
+    <article className="project-row">
+      <h3 className="row-title">{title}</h3>
+      {description ? <p className="row-dek">{description}</p> : null}
+      <div className="row-links">
+        {liveUrl ? (
+          <a href={liveUrl} target="_blank" rel="noreferrer">
+            Live demo
+          </a>
+        ) : null}
+        {repoUrl ? (
+          <a href={repoUrl} target="_blank" rel="noreferrer">
+            Source
+          </a>
+        ) : null}
+      </div>
+    </article>
+  );
+}

--- a/app/components/site/top-bar.tsx
+++ b/app/components/site/top-bar.tsx
@@ -1,0 +1,75 @@
+import * as React from "react";
+import { Link, useLocation } from "react-router";
+
+import { ThemeToggle } from "~/components/blog/theme-toggle";
+
+const SECTIONS = [
+  { label: "Home", to: "/" },
+  { label: "Blog", to: "/blog" },
+] as const;
+
+function isActive(pathname: string, to: string) {
+  if (to === "/") return pathname === "/";
+  return pathname === to || pathname.startsWith(`${to}/`);
+}
+
+export function TopBar() {
+  const { pathname } = useLocation();
+  const [open, setOpen] = React.useState(false);
+
+  React.useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
+
+  return (
+    <>
+      <header className="site-topbar" role="banner">
+        <Link to="/" prefetch="intent" className="brand">
+          Jimmy Van Veen
+        </Link>
+        <nav className="section-nav" aria-label="Primary">
+          {SECTIONS.map((section) => (
+            <Link
+              key={section.to}
+              to={section.to}
+              prefetch="intent"
+              aria-current={isActive(pathname, section.to) ? "page" : undefined}
+            >
+              {section.label}
+            </Link>
+          ))}
+        </nav>
+        <div className="spacer" />
+        <button
+          type="button"
+          className="menu-button"
+          aria-expanded={open}
+          aria-controls="site-mobile-sheet"
+          onClick={() => setOpen((o) => !o)}
+        >
+          {open ? "Close" : "Menu"}
+        </button>
+        <ThemeToggle />
+      </header>
+      {open ? (
+        <div
+          id="site-mobile-sheet"
+          className="site-mobile-sheet"
+          role="dialog"
+          aria-label="Site navigation"
+        >
+          {SECTIONS.map((section) => (
+            <Link
+              key={section.to}
+              to={section.to}
+              prefetch="intent"
+              aria-current={isActive(pathname, section.to) ? "page" : undefined}
+            >
+              {section.label}
+            </Link>
+          ))}
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -6,12 +6,9 @@ import {
   Scripts,
   ScrollRestoration,
   isRouteErrorResponse,
-  useLocation,
 } from "react-router";
 
-import { AppHeader, type BlogTopics } from "~/components/app-header";
-import { AppSidebar } from "~/components/app-sidebar/app-sidebar";
-import { SidebarInset, SidebarProvider } from "~/components/ui/sidebar";
+import { TopBar } from "~/components/site/top-bar";
 import { getCachedBlogPosts } from "~/utils/contentful-cache";
 
 import type { Route } from "./+types/root";
@@ -33,7 +30,7 @@ export const links: Route.LinksFunction = () => {
     },
     {
       rel: "stylesheet",
-      href: "https://fonts.googleapis.com/css2?family=Raleway:ital,wght@0,100..900;1,100..900&family=Source+Sans+3:ital,wght@0,200..900;1,200..900&family=Fraunces:ital,opsz,wght,SOFT@0,9..144,300..900,30;1,9..144,300..900,30&family=Source+Serif+4:ital,opsz,wght@0,8..60,300..900;1,8..60,300..900&family=JetBrains+Mono:ital,wght@0,400..700;1,400..700&display=swap",
+      href: "https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300..800;1,6..72,300..800&family=Source+Serif+4:ital,opsz,wght@0,8..60,300..900;1,8..60,300..900&family=Fraunces:ital,opsz,wght@1,9..144,300..700&family=JetBrains+Mono:ital,wght@0,400..700;1,400..700&display=swap",
     },
     { rel: "stylesheet", href: styles },
   ];
@@ -44,14 +41,9 @@ export async function loader() {
 
   return blogPosts.map((blog) => ({
     title: blog.fields.title,
-    date: new Date(blog.fields.publishDate)
-      .toLocaleDateString("en-us", {
-        month: "long",
-        day: "numeric",
-        year: "numeric",
-      })
-      .toString(),
-    link: blog.fields.slug,
+    description: blog.fields.description ?? "",
+    slug: blog.fields.slug,
+    publishDate: blog.fields.publishDate,
   }));
 }
 
@@ -74,11 +66,11 @@ export function Layout({ children }: { children: React.ReactNode }) {
   );
 }
 
-export default function App({ loaderData }: Route.ComponentProps) {
+export default function App() {
   return (
-    <Template blogPosts={loaderData}>
+    <Shell>
       <Outlet />
-    </Template>
+    </Shell>
   );
 }
 
@@ -99,41 +91,42 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
   }
 
   return (
-    <Template>
-      <main className="pt-16 p-4 container mx-auto">
-        <h1>{message}</h1>
-        <p>{details}</p>
-        {stack && (
-          <pre className="w-full p-4 overflow-x-auto">
+    <Shell>
+      <main className="blog-page">
+        <h1
+          style={{
+            fontFamily: "var(--font-display)",
+            fontSize: "clamp(2rem, 5vw, 3.5rem)",
+            fontWeight: 500,
+            marginBottom: "1rem",
+          }}
+        >
+          {message}
+        </h1>
+        <p
+          style={{
+            fontFamily: "var(--font-serif)",
+            fontStyle: "italic",
+            color: "var(--blog-muted)",
+          }}
+        >
+          {details}
+        </p>
+        {stack ? (
+          <pre className="prose-editorial">
             <code>{stack}</code>
           </pre>
-        )}
+        ) : null}
       </main>
-    </Template>
+    </Shell>
   );
 }
 
-function Template({
-  children,
-  blogPosts,
-}: {
-  children: React.ReactNode;
-  blogPosts?: BlogTopics[];
-}) {
-  const location = useLocation();
-  const isBlogRoute = location.pathname.startsWith("/blog");
-
-  if (isBlogRoute) {
-    return <div className="min-h-screen">{children}</div>;
-  }
-
+function Shell({ children }: { children: React.ReactNode }) {
   return (
-    <SidebarProvider className="flex flex-col">
-      <AppHeader blogs={blogPosts} />
-      <div className="flex flex-1">
-        <AppSidebar />
-        <SidebarInset className="bg-black">{children}</SidebarInset>
-      </div>
-    </SidebarProvider>
+    <div className="editorial-theme">
+      <TopBar />
+      {children}
+    </div>
   );
 }

--- a/app/routes/blog/$slug.tsx
+++ b/app/routes/blog/$slug.tsx
@@ -7,6 +7,7 @@ import rehypeExternalLinks from "rehype-external-links";
 import { PostFooter } from "~/components/blog/post-footer";
 import { PostHero } from "~/components/blog/post-hero";
 import { ReadingProgress } from "~/components/blog/reading-progress";
+import { Plate } from "~/components/site/plate";
 import { trackPageView } from "~/utils/analytics-loader";
 import { editorialPrismStyle } from "~/utils/code-theme";
 import { getCachedBlogPostBySlug } from "~/utils/contentful-cache";
@@ -60,6 +61,12 @@ export default function Post({ loaderData: blog }: Route.ComponentProps) {
         >
           <ReactMarkdown
             components={{
+              img({ src, alt, title }) {
+                if (!src || typeof src !== "string") return null;
+                return (
+                  <Plate src={src} alt={alt ?? ""} caption={title || alt} />
+                );
+              },
               code({ node: _node, className, children, ...props }) {
                 const match = /language-(\w+)/.exec(className ?? "");
                 return match ? (

--- a/app/routes/blog/layout.tsx
+++ b/app/routes/blog/layout.tsx
@@ -1,17 +1,5 @@
-import { Link, Outlet } from "react-router";
-
-import { ThemeToggle } from "~/components/blog/theme-toggle";
+import { Outlet } from "react-router";
 
 export default function Blog() {
-  return (
-    <div className="blog-theme">
-      <header className="blog-topbar">
-        <Link to="/" prefetch="intent" className="brand">
-          ← Jimmy Van Veen
-        </Link>
-        <ThemeToggle />
-      </header>
-      <Outlet />
-    </div>
-  );
+  return <Outlet />;
 }

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,31 +1,28 @@
-// Libs
 import * as React from "react";
-import { Await } from "react-router";
+import { Await, Link, useRouteLoaderData } from "react-router";
+import { format } from "date-fns";
 
-import ContentCards, { ContentCard } from "~/components/content-cards";
-// Components
-import GradientBanner from "~/components/gradient-banner";
-import Project from "~/components/project";
+import { Plate } from "~/components/site/plate";
+import { ProjectRow } from "~/components/site/project-row";
 import { trackPageView } from "~/utils/analytics-loader";
 import { getCachedProjects } from "~/utils/contentful-cache";
-// Utils
 import { getRepositoriesByNodeId } from "~/utils/github";
 
 import type { Route } from "./+types/index";
 
 interface Repository {
-  /** The name of the repository */
   name: string;
-  /** The ID of the repository */
   id: number;
-  /** The URL for the repository on GitHub */
   homepageUrl: string | null;
-  /** The description of the repository */
   description: string | null;
-  /** The URL for the repository on GitHub */
   url: string;
-  /** The URL for the screenshot */
-  screenshotUrl?: string;
+}
+
+interface RootBlogPost {
+  title: string;
+  description: string;
+  slug: string;
+  publishDate: string;
 }
 
 export async function loader() {
@@ -36,169 +33,186 @@ export async function loader() {
         .sort((a, b) => Number(a.fields.priority) - Number(b.fields.priority))
         .map((p) => p.fields.ghId),
     );
-    const repositories: Repository[] = repos.map((repo) => {
-      const project = projects.find((p) => p.fields.ghId === repo.node_id);
-      return {
-        name: repo.name,
-        id: repo.id,
-        homepageUrl: repo.homepage,
-        description: repo.description,
-        url: repo.html_url,
-        screenshotUrl:
-          project?.fields.screenshot && "fields" in project.fields.screenshot
-            ? project.fields.screenshot.fields.file?.url
-            : undefined,
-      } satisfies Repository;
-    });
+    const repositories: Repository[] = repos.map((repo) => ({
+      name: repo.name,
+      id: repo.id,
+      homepageUrl: repo.homepage,
+      description: repo.description,
+      url: repo.html_url,
+    }));
     return repositories;
   }
 
   return getData();
 }
 
-// Add analytics tracking to this route
 export async function clientLoader({ serverLoader }: Route.ClientLoaderArgs) {
   const result = await serverLoader();
-
-  // Track page view in background
   trackPageView().catch((error) => {
     console.warn("Analytics tracking failed:", error);
   });
-
   return result;
 }
 clientLoader.hydrate = true;
 
 export default function Index({ loaderData: repos }: Route.ComponentProps) {
-  return (
-    <div className="min-h-screen bg-black">
-      <GradientBanner>
-        <h2 className="text-2xl font-mono mb-4 text-white">
-          Mission Statement
-        </h2>
-        <p className="text-[#B0B0B0] text-lg leading-relaxed pb-20">
-          My mission is to create innovative and user-centric digital
-          experiences that seamlessly blend aesthetics with functionality. I
-          strive to push the boundaries of web design and game development,
-          always aiming to deliver solutions that not only meet but exceed user
-          expectations.
-        </p>
-      </GradientBanner>
+  const rootData = useRouteLoaderData("root") as RootBlogPost[] | undefined;
+  const recentPosts = (rootData ?? []).slice(0, 3);
 
-      <ContentCards spacing="space-y-8 -mt-40 relative z-10">
-        <ContentCard title="Projects">
-          <React.Suspense fallback={"Loading projects..."}>
-            <Await resolve={repos} errorElement={"Could not load projects"}>
-              {(resolvedRepos) => {
-                return (
-                  <section className="md:grid md:gap-8 pb-10 md:grid-cols-2">
-                    {resolvedRepos.map((repo: Repository) => {
-                      return (
-                        <Project
-                          key={repo.id}
-                          title={repo.name}
-                          description={repo.description}
-                          repoUrl={repo.url}
-                          url={repo.homepageUrl}
-                          screenshotUrl={repo.screenshotUrl}
-                        />
-                      );
-                    })}
-                  </section>
-                );
-              }}
+  return (
+    <main className="home-cover">
+      <div className="home-text">
+        <div className="home-dateline">
+          Jimmy Van Veen · Web engineer · Detroit
+        </div>
+        <h1 className="home-title">
+          I build software, write down what I learn, and race cars on the
+          internet.
+        </h1>
+        <p className="home-dek">
+          A working portfolio &mdash; projects I&rsquo;ve shipped, notes from
+          the workshop, and the occasional lap at Talladega. The interesting
+          stuff is in the writing.
+        </p>
+      </div>
+
+      <Plate
+        className="home-hero-plate"
+        src="/images/talladega_glory.jpg"
+        alt="A pack of stock cars running three-wide down the front stretch at Talladega Superspeedway."
+        caption="Plate I — Three-wide at Talladega"
+      />
+
+      <div className="home-sections">
+        {recentPosts.length > 0 ? (
+          <section className="home-section">
+            <div className="head">
+              <h2>Recent writing</h2>
+              <Link to="/blog" prefetch="intent" className="see-all">
+                All posts →
+              </Link>
+            </div>
+            <ul className="blog-index-list">
+              {recentPosts.map((post) => (
+                <li className="blog-index-row" key={post.slug}>
+                  <Link to={`/blog/${post.slug}`} prefetch="intent">
+                    <div className="meta">
+                      {format(new Date(post.publishDate), "MMMM d, yyyy")}
+                    </div>
+                    <h3 className="title">{post.title}</h3>
+                    {post.description ? (
+                      <p className="dek">{post.description}</p>
+                    ) : null}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ) : null}
+
+        <section className="home-section">
+          <div className="head">
+            <h2>Selected work</h2>
+            <a
+              href="https://github.com/JimmayVV"
+              target="_blank"
+              rel="noreferrer"
+              className="see-all"
+            >
+              GitHub →
+            </a>
+          </div>
+          <React.Suspense fallback={<ProjectsFallback />}>
+            <Await resolve={repos} errorElement={<ProjectsError />}>
+              {(resolvedRepos) => (
+                <div>
+                  {resolvedRepos.slice(0, 4).map((repo: Repository) => (
+                    <ProjectRow
+                      key={repo.id}
+                      title={repo.name}
+                      description={repo.description}
+                      liveUrl={repo.homepageUrl}
+                      repoUrl={repo.url}
+                    />
+                  ))}
+                </div>
+              )}
             </Await>
           </React.Suspense>
-        </ContentCard>
-      </ContentCards>
-    </div>
+        </section>
+      </div>
+
+      <SiteFooter />
+    </main>
   );
 }
 
-export function ErrorBoundary({ error }: { error: Error }) {
-  // Check if this is a GitHub API authentication error
-  // These errors typically have "Requires authentication" in the message
-  // and come with a 401 status
-  const isGitHubAuthError =
-    error?.message?.includes("Requires authentication") ||
-    error?.message?.includes("401") ||
-    error?.message?.includes("Bad credentials") ||
-    error?.message?.includes("Unauthorized");
-
-  // For GitHub auth errors, render the normal page layout with an error message
-  if (isGitHubAuthError) {
-    return (
-      <div className="min-h-screen bg-black">
-        <GradientBanner>
-          <h2 className="text-2xl font-mono mb-4 text-white">
-            Mission Statement
-          </h2>
-          <p className="text-[#B0B0B0] text-lg leading-relaxed pb-20">
-            My mission is to create innovative and user-centric digital
-            experiences that seamlessly blend aesthetics with functionality. I
-            strive to push the boundaries of web design and game development,
-            always aiming to deliver solutions that not only meet but exceed
-            user expectations.
-          </p>
-        </GradientBanner>
-
-        <ContentCards spacing="space-y-8 -mt-40 relative z-10">
-          <ContentCard title="Projects">
-            <div className="bg-yellow-50 dark:bg-yellow-950/20 border border-yellow-200 dark:border-yellow-800 p-6 rounded-lg mb-6">
-              <div className="flex items-start gap-4">
-                <svg
-                  className="w-8 h-8 text-yellow-600 dark:text-yellow-500 mt-0.5 flex-shrink-0"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-                  />
-                </svg>
-                <div className="flex-1">
-                  <h3 className="text-lg font-bold text-yellow-900 dark:text-yellow-100 mb-2">
-                    GitHub API Configuration Required
-                  </h3>
-                  <p className="text-base font-medium text-yellow-800 dark:text-yellow-200 mb-4">
-                    Projects cannot be loaded without GitHub API access. The
-                    portfolio data is temporarily unavailable.
-                  </p>
-                  <a
-                    href="https://github.com/JimmayVV?tab=repositories"
-                    className="inline-flex items-center text-base font-semibold text-yellow-700 dark:text-yellow-400 hover:text-yellow-900 dark:hover:text-yellow-300"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    View projects on GitHub
-                  </a>
-                </div>
-              </div>
-            </div>
-          </ContentCard>
-        </ContentCards>
-      </div>
-    );
-  }
-
-  // For other errors, show a more generic error boundary
+function ProjectsFallback() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-black text-white">
-      <div className="max-w-md text-center">
-        <h1 className="text-4xl font-bold mb-4">Something went wrong</h1>
-        <p className="text-gray-400 mb-6">
-          An unexpected error occurred. Please try refreshing the page.
-        </p>
-        <a
-          href="/"
-          className="inline-block px-6 py-3 bg-white text-black font-medium rounded hover:bg-gray-200 transition"
-        >
-          Go Home
+    <p
+      style={{
+        fontFamily: "var(--font-serif)",
+        fontStyle: "italic",
+        color: "var(--blog-muted)",
+      }}
+    >
+      Loading projects&hellip;
+    </p>
+  );
+}
+
+function ProjectsError() {
+  return (
+    <p
+      style={{
+        fontFamily: "var(--font-serif)",
+        fontStyle: "italic",
+        color: "var(--blog-muted)",
+      }}
+    >
+      Couldn&rsquo;t reach GitHub right now. Try again later, or browse{" "}
+      <a
+        href="https://github.com/JimmayVV"
+        style={{ color: "var(--blog-accent)" }}
+      >
+        the source on GitHub
+      </a>
+      .
+    </p>
+  );
+}
+
+function SiteFooter() {
+  return (
+    <footer className="site-footer">
+      <span>© Jimmy Van Veen</span>
+      <div className="footer-links">
+        <a href="https://github.com/JimmayVV" target="_blank" rel="noreferrer">
+          GitHub
         </a>
+        <a
+          href="https://bsky.app/profile/jimmyvanveen.com"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Bluesky
+        </a>
+        <Link to="/privacy" prefetch="intent">
+          Privacy
+        </Link>
       </div>
-    </div>
+    </footer>
+  );
+}
+
+export function ErrorBoundary() {
+  return (
+    <main className="home-cover">
+      <h1 className="home-title">Something went wrong</h1>
+      <p className="home-dek">
+        An unexpected error occurred while loading the home page. Try
+        refreshing.
+      </p>
+    </main>
   );
 }


### PR DESCRIPTION
> **Targets `feature/blog-editorial-redesign`** (PR #303), not `main` — so the diff here is just the round-2 incremental changes. Merging order: review/merge #303 first, then this.

## Summary

Round 2 — extends the blog's editorial language to the whole site so home, projects, and blog feel like one publication. Addresses the feedback from #303:

- **Sidebar didn't match the blog** → replaced with a global slim TopBar (brand · section nav · theme toggle) used on every page
- **Fraunces ampersand was ugly** → headlines switched to **Newsreader** (restrained, well-drawn `&`, true `opsz` axis). Fraunces is now used only for italic blockquotes and the drop cap, where its character earns it
- **Home looked nothing like the blog** → rewritten as an editorial cover: dateline, big serif title, italic dek, hero plate (Talladega), then "Recent writing" + "Selected work" sections, then a small mono footer
- **Theme toggle wasn't site-wide** → now mounted in the global TopBar, available on every page
- **Photographs**: new `<Plate>` component (desaturated, hairline-framed, mono caption). Used for the home hero and wired into the markdown `img` renderer so any image in a post body gets the same treatment

## New components

- `app/components/site/top-bar.tsx` — global navigation chrome, mobile sheet under 720px
- `app/components/site/plate.tsx` — sparing photo treatment
- `app/components/site/project-row.tsx` — editorial project list item

## Modified

- `app/root.tsx` — strip `SidebarProvider`/`AppHeader`/`AppSidebar` from the shell; mount `<TopBar>` globally; apply `.editorial-theme` class
- `app/app.css` — add `--font-display` (Newsreader) / `--font-display-italic` (Fraunces); rename `.blog-theme` → `.editorial-theme` (alias both); swap headline rules to Newsreader; add TopBar / Plate / ProjectRow / home-cover / site-footer styles
- `app/routes/index.tsx` — full rewrite to the editorial cover layout
- `app/routes/blog/layout.tsx` — drop the local top bar (now global)
- `app/routes/blog/\$slug.tsx` — wire `<Plate>` into the markdown image renderer

## Navigation from a blog post

Per your ask: from a single blog post, both **Home** and **All posts** are reachable in equally one click each — Home via the brand link in the TopBar, All posts via the "Blog" section nav (and still via the existing "← All posts" in the post footer).

## Stops being mounted (left in codebase)

`AppHeader`, `AppSidebar`, `Header`, `Banner`, `Mission`, `ContentCards`, `GradientBanner`, and the shadcn `sidebar.tsx` are no longer rendered. Cleanup PR can delete them once this is merged.

Plan: [`Plans/cohesive-site-editorial-pass.md`](Plans/cohesive-site-editorial-pass.md)

## Test plan

- [ ] `/`, `/blog`, `/blog/<slug>` all render with the same TopBar, palette, and fonts — feels like one publication
- [ ] No Fraunces ampersand visible anywhere in headlines
- [ ] Theme toggle works on every page; persists across navigation; no FOUC
- [ ] Home hero plate renders with caption, desaturated, reflows below the title under 1100px
- [ ] From a blog post: clicking "Jimmy Van Veen" goes home; clicking "Blog" goes to all posts; both equally one click
- [ ] Mobile (375px): TopBar collapses cleanly, "Menu" toggles inline sheet, hero plate stacks under title
- [ ] Wide desktop (≥1400px): home text/plate sit side-by-side, blog measure stays at 66ch
- [ ] `npm run lint` / `npm run typecheck` / `npm run build` clean