### PR TITLE
fix(analytics): use structured logger for background tracking failures

### DIFF
--- a/app/utils/analytics-loader.ts
+++ b/app/utils/analytics-loader.ts
@@ -84,9 +84,7 @@ export async function withServerLoaderAnalytics(
   const result = await args.serverLoader();
 
   // Track page view in background to not block the loader
-  trackPageView().catch((error) => {
-    console.warn("Analytics tracking failed:", error);
-  });
+  trackPageView().catch(reportBackgroundAnalyticsFailure);
 
   return result;
 }
@@ -97,11 +95,32 @@ export async function withServerLoaderAnalytics(
  */
 export async function withCustomLoaderAnalytics<T>(data: T): Promise<T> {
   // Track page view in background to not block the loader
-  trackPageView().catch((error) => {
-    console.warn("Analytics tracking failed:", error);
-  });
+  trackPageView().catch(reportBackgroundAnalyticsFailure);
 
   return data;
+}
+
+/**
+ * Report a background analytics failure via the structured logger.
+ *
+ * Wrapped in try/catch because both helpers above invoke this in
+ * fire-and-forget `.catch()` handlers — if the logger itself fails to
+ * resolve (e.g. dynamic import of `logger.client` throws), we must not
+ * surface an unhandled promise rejection. The console.warn fallback
+ * preserves visibility in that degenerate path.
+ */
+async function reportBackgroundAnalyticsFailure(error: unknown): Promise<void> {
+  try {
+    const logger = await getRouteLogger();
+    logger.warn({ error }, "Analytics tracking failed in background");
+  } catch (loggerError) {
+    // Last-resort fallback when the structured logger itself fails to load.
+    console.warn(
+      "Analytics tracking failed and structured logger unavailable:",
+      error,
+      loggerError,
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #199.

## Summary

Replace bare `console.warn` calls in `withServerLoaderAnalytics` and `withCustomLoaderAnalytics` background error handlers with the project's structured logger (`getRouteLogger`), matching the pattern already used elsewhere in `analytics-loader.ts` (lines 45, 71).

## Implementation note

Extracted into a shared `reportBackgroundAnalyticsFailure` helper. The helper is defensive — wraps `getRouteLogger()` in a try/catch so a logger-loading failure (e.g. dynamic `import("./logger.client")` rejects) can't surface as an unhandled promise rejection. These helpers are invoked from fire-and-forget `.catch()` handlers, so an unhandled rejection from the catch itself would silently drop both errors. The `console.warn` fallback preserves visibility in that degenerate path.

## Test plan

- [x] `npm run lint` — no new warnings or errors
- [x] `npm run typecheck` — clean
- [x] `npm test` — 67/67 tests pass
- [x] `npm run build` — clean

Behavior change is only in the error logging path (formerly silently warned, now goes through structured logger). No functional change for successful page-view tracking.