### PR TITLE
chore(deps): unpin eslint-plugin-react-hooks 7.0.1 → 7.1.1

### DIFF
--- a/app/components/site/theme-toggle.tsx
+++ b/app/components/site/theme-toggle.tsx
@@ -1,13 +1,4 @@
-/* eslint-disable react-hooks/set-state-in-effect --
- * `setMounted(true)` in a mount-time effect is the canonical SSR/CSR
- * hydration pattern: render an aria-hidden placeholder on the server (where
- * `document` is undefined), then swap in the real toggle once we know the
- * actual theme class on `<html>`. The rule's warning about cascading renders
- * is correct in general, but here the second render IS the point — it's how
- * we avoid a hydration mismatch and a flash of wrong-themed icon. Migrating
- * to `useSyncExternalStore` would work but is a 20-line rewrite for a single
- * post-mount re-render; not worth it for this small component.
- */
+/* eslint-disable react-hooks/set-state-in-effect -- canonical SSR mount-swap pattern; useSyncExternalStore not worth the rewrite for one post-mount render */
 import * as React from "react";
 
 type Theme = "light" | "dark";

--- a/app/components/site/theme-toggle.tsx
+++ b/app/components/site/theme-toggle.tsx
@@ -1,3 +1,13 @@
+/* eslint-disable react-hooks/set-state-in-effect --
+ * `setMounted(true)` in a mount-time effect is the canonical SSR/CSR
+ * hydration pattern: render an aria-hidden placeholder on the server (where
+ * `document` is undefined), then swap in the real toggle once we know the
+ * actual theme class on `<html>`. The rule's warning about cascading renders
+ * is correct in general, but here the second render IS the point — it's how
+ * we avoid a hydration mismatch and a flash of wrong-themed icon. Migrating
+ * to `useSyncExternalStore` would work but is a 20-line rewrite for a single
+ * post-mount re-render; not worth it for this small component.
+ */
 import * as React from "react";
 
 type Theme = "light" | "dark";

--- a/app/components/site/top-bar.tsx
+++ b/app/components/site/top-bar.tsx
@@ -19,16 +19,7 @@ export function TopBar() {
   const triggerRef = React.useRef<HTMLButtonElement>(null);
   const firstLinkRef = React.useRef<HTMLAnchorElement>(null);
 
-  // Close the mobile sheet whenever the route changes. Stored as "info from
-  // a previous render" per React's docs[1] — setting state during render
-  // (guarded so it only fires on actual pathname change) is preferred over
-  // an effect for this kind of cross-render reset, because it avoids the
-  // cascading-render warning the react-hooks/set-state-in-effect rule
-  // (correctly) emits for the effect form. Using useState (not useRef) for
-  // the comparison value is intentional: refs aren't permitted to mutate
-  // during render under the newer react-hooks/refs rule.
-  //
-  // [1] https://react.dev/reference/react/useState#storing-information-from-previous-renders
+  // Reset `open` on route change via "info from previous renders": https://react.dev/reference/react/useState#storing-information-from-previous-renders
   const [prevPathname, setPrevPathname] = React.useState(pathname);
   if (prevPathname !== pathname) {
     setPrevPathname(pathname);

--- a/app/components/site/top-bar.tsx
+++ b/app/components/site/top-bar.tsx
@@ -19,9 +19,21 @@ export function TopBar() {
   const triggerRef = React.useRef<HTMLButtonElement>(null);
   const firstLinkRef = React.useRef<HTMLAnchorElement>(null);
 
-  React.useEffect(() => {
+  // Close the mobile sheet whenever the route changes. Stored as "info from
+  // a previous render" per React's docs[1] — setting state during render
+  // (guarded so it only fires on actual pathname change) is preferred over
+  // an effect for this kind of cross-render reset, because it avoids the
+  // cascading-render warning the react-hooks/set-state-in-effect rule
+  // (correctly) emits for the effect form. Using useState (not useRef) for
+  // the comparison value is intentional: refs aren't permitted to mutate
+  // during render under the newer react-hooks/refs rule.
+  //
+  // [1] https://react.dev/reference/react/useState#storing-information-from-previous-renders
+  const [prevPathname, setPrevPathname] = React.useState(pathname);
+  if (prevPathname !== pathname) {
+    setPrevPathname(pathname);
     setOpen(false);
-  }, [pathname]);
+  }
 
   // Escape closes the mobile sheet and returns focus to the trigger so
   // keyboard users aren't stranded inside an open menu.

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-prettier": "^5.5.4",
         "eslint-plugin-react": "^7.37.5",
-        "eslint-plugin-react-hooks": "~7.0.1",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "eslint-plugin-unused-imports": "^4.3.0",
         "globals": "^17.6.0",
@@ -5620,13 +5620,6 @@
         "tailwindcss": "4.3.0"
       }
     },
-    "node_modules/@tailwindcss/node/node_modules/tailwindcss": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
-      "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@tailwindcss/oxide": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
@@ -5948,13 +5941,6 @@
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
-    },
-    "node_modules/@tailwindcss/vite/node_modules/tailwindcss": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
-      "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@tanstack/devtools": {
       "version": "0.10.14",
@@ -10426,9 +10412,9 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
-      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10442,7 +10428,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-react-refresh": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-prettier": "^5.5.4",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "~7.0.1",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "eslint-plugin-unused-imports": "^4.3.0",
     "globals": "^17.6.0",


### PR DESCRIPTION
Closes #282.

## Summary

Bumps `eslint-plugin-react-hooks` from `~7.0.1` to `^7.1.1`. The original violations from issue #282 (`app/hooks/use-mobile.ts`, `app/components/ui/carousel.tsx`) no longer exist — both files were deleted in the editorial-redesign commit (110d0fa).

## Two new violations surfaced

### \`app/components/site/top-bar.tsx:23\` — refactored

The pathname-keyed effect that reset \`open\` to \`false\` on route change is now expressed as React's [\"storing info from previous renders\"](https://react.dev/reference/react/useState#storing-information-from-previous-renders) pattern. setState happens during render, guarded by \`prevPathname !== pathname\`, using \`useState\` (not \`useRef\`) because the newer \`react-hooks/refs\` rule forbids ref mutation during render.

### \`app/components/site/theme-toggle.tsx:19\` — rule disabled at file level

The \`setMounted(true)\` post-mount effect is the canonical SSR/CSR hydration pattern: render an aria-hidden placeholder on the server, swap to the real button after hydration. The rule warns about cascading renders, but the second render IS the point here — it's how we avoid a hydration mismatch and a flash of wrong-themed icon. Migrating to \`useSyncExternalStore\` would be a 20-line rewrite for a single post-mount render. File-level disable with explanation seemed proportionate.

## Test plan

- [x] \`npm run lint\` — clean
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 67/67 tests pass
- [x] \`npm run build\` — clean

Behavior change: the top-bar mobile-sheet close-on-route-change should be indistinguishable from before.