### PR TITLE
chore: address optional polish from PRs #309–312 Claude reviews

### DIFF
--- a/app/components/site/theme-toggle.tsx
+++ b/app/components/site/theme-toggle.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/set-state-in-effect -- canonical SSR mount-swap pattern; useSyncExternalStore not worth the rewrite for one post-mount render */
 import * as React from "react";
 
 type Theme = "light" | "dark";
@@ -17,6 +16,7 @@ export function ThemeToggle() {
   const [mounted, setMounted] = React.useState(false);
 
   React.useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- canonical SSR mount-swap; not worth a useSyncExternalStore rewrite for one post-mount render
     setMounted(true);
   }, []);
 

--- a/app/utils/analytics-loader.ts
+++ b/app/utils/analytics-loader.ts
@@ -100,15 +100,7 @@ export async function withCustomLoaderAnalytics<T>(data: T): Promise<T> {
   return data;
 }
 
-/**
- * Report a background analytics failure via the structured logger.
- *
- * Wrapped in try/catch because both helpers above invoke this in
- * fire-and-forget `.catch()` handlers — if the logger itself fails to
- * resolve (e.g. dynamic import of `logger.client` throws), we must not
- * surface an unhandled promise rejection. The console.warn fallback
- * preserves visibility in that degenerate path.
- */
+// Fire-and-forget; logger try/catch prevents unhandled rejection if `logger.client` import throws.
 async function reportBackgroundAnalyticsFailure(error: unknown): Promise<void> {
   try {
     const logger = await getRouteLogger();

--- a/config/oxlintrc.json
+++ b/config/oxlintrc.json
@@ -3,7 +3,7 @@
   "plugins": ["import", "react", "typescript", "unicorn", "oxc"],
   "rules": {
     "no-unused-vars": [
-      "warn",
+      "error",
       {
         "argsIgnorePattern": "^_",
         "varsIgnorePattern": "^_",

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,7 @@
         "vitest": "^4.1.5"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,8 @@
 {
+  "//pin-notes": {
+    "typescript": "Tilde pin (~6.0.3): typescript-eslint peer dep caps at <6.1.0, so caret would pull 6.1.x and break tsc.",
+    "eslint-plugin-react-hooks": "Caret pin (^7.1.1) since #310; ESLint 10 still blocked by eslint-plugin-react / jsx-a11y peer ranges (see #295)."
+  },
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Bundles all four optional follow-ups Claude raised on the merged issue-cleanup PRs (#309, #310, #311, #312).

## Changes

1. **(from #309)** Trim the JSDoc on \`reportBackgroundAnalyticsFailure\` from a 9-line block to a single line. Matches CLAUDE.md's "one short line max" convention.

2. **(from #310)** Narrow the \`eslint-disable react-hooks/set-state-in-effect\` in \`theme-toggle.tsx\` from file-level to line-level. A file-level disable could silence a future legitimate violation elsewhere in the file — line-level pinpoints exactly the SSR mount-swap.

3. **(from #311)** Add a top-level \`//pin-notes\` object in \`package.json\` explaining the tilde pin on \`typescript\` and the caret-after-tilde on \`eslint-plugin-react-hooks\`. Inline \`//\`-prefixed keys inside \`devDependencies\` are rejected by npm as invalid package names — top-level is the npm-tolerated comment convention.

4. **(from #312)** Promote oxlint's \`no-unused-vars\` from \`warn\` to \`error\`. The eslint side of the project already treats unused vars as a hard error via \`unused-imports/no-unused-vars\`. Matching severity makes oxlint a true blocking gate.

## Incidental

\`package-lock.json\` engines field synced from \`>=20.19.0\` → \`^20.19.0 || >=22.12.0\` to match the \`package.json\` change that landed in #312. Passive: \`npm install\` regenerated it while testing this PR's pin-notes change.

## Test plan

- [x] \`npm run lint:fast\` — 0 warnings, 0 errors
- [x] \`npm run lint\` — clean
- [x] \`npm run typecheck\` — clean
- [x] \`npm test\` — 67/67 pass
- [x] \`npm run build\` — clean

No behavior changes anywhere. Pure docs/severity polish.