### PR TITLE
chore(review): address non-blocking review nits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Implementation plans (kept locally for context, not committed)
 /Plans/
+.atrium/
+.mcp.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,14 +51,16 @@ npm start
 Hard-won lessons — follow these to avoid green-locally / red-in-CI loops:
 
 - **Regenerate `package-lock.json` with the pinned Node/npm, not whatever is
-  newest locally.** CI and Netlify build on **Node 22 (npm 10)** — the version
-  in `.nvmrc` / `netlify.toml`. A newer npm (e.g. 11) dedupes transitive deps
-  differently and writes a lock that npm 10's `npm ci` rejects with
-  `Missing: <pkg> from lock file` — which surfaces as a CI "Install
-  dependencies" failure _and_ a Netlify deploy-preview failure, while
-  `npm install`/`npm ci` still pass locally on the newer npm. Before touching
-  the lockfile: `nvm use` (reads `.nvmrc` → 22), or run `npx npm@10 install`.
-  Sanity-check with `npx npm@10 ci --dry-run` before pushing.
+  newest locally.**
+  - CI and Netlify build on **Node 22 (npm 10)** — the version in `.nvmrc` /
+    `netlify.toml`.
+  - A newer npm (e.g. 11) dedupes transitive deps differently and writes a lock
+    that npm 10's `npm ci` rejects with `Missing: <pkg> from lock file`.
+  - It surfaces as a CI "Install dependencies" failure _and_ a Netlify
+    deploy-preview failure, while `npm install`/`npm ci` still pass locally on
+    the newer npm.
+  - Before touching the lockfile, `nvm use` (reads `.nvmrc` → 22) or
+    `npx npm@10 install`, then sanity-check with `npx npm@10 ci --dry-run`.
 - **A broken lock can poison Netlify's build cache.** If a bad lock was pushed
   once, later good pushes may still fail install because Netlify reuses the
   cached state. Fix: **Clear cache and deploy** in the Netlify UI (or the

--- a/app/routes/api.events.tsx
+++ b/app/routes/api.events.tsx
@@ -287,10 +287,6 @@ function getClientIP(request: Request): string {
 function sanitizeProperties(
   properties: Record<string, unknown>,
 ): Record<string, unknown> | null {
-  if (!properties || typeof properties !== "object") {
-    return {};
-  }
-
   function sanitizeValue(value: unknown, depth: number): unknown {
     if (depth >= MAX_PROPERTY_DEPTH) {
       return "[Object too deep]";

--- a/config/eslint.config.js
+++ b/config/eslint.config.js
@@ -126,16 +126,14 @@ export default tseslint.config(
     ...tseslint.configs.disableTypeChecked,
   },
   {
-    // Tests legitimately use `any`, casts, and mocks; type-aware rules
-    // (no-unsafe-*, etc.) add noise, not safety, here.
+    // Tests legitimately use `any`, casts, and mocks, so the type-aware rules
+    // (no-unsafe-*, etc.) and the `as` ban add noise, not safety, here.
+    // TODO(#381): migrate test/e2e `as` assertions to @total-typescript/
+    // shoehorn, then drop the consistent-type-assertions override below.
     files: ["**/*.test.{ts,tsx}", "e2e/**/*.ts"],
     ...tseslint.configs.disableTypeChecked,
-  },
-  {
-    // TODO(#381): migrate test/e2e `as` assertions to @total-typescript/
-    // shoehorn, then remove this exemption so the ban is project-wide.
-    files: ["**/*.test.{ts,tsx}", "e2e/**/*.ts"],
     rules: {
+      ...tseslint.configs.disableTypeChecked.rules,
       "@typescript-eslint/consistent-type-assertions": "off",
     },
   },


### PR DESCRIPTION
## Summary

Follow-up cleanup for the non-blocking nits flagged in the automated reviews of #379/#380.

- **`config/eslint.config.js`** — merge the two duplicate `["**/*.test.{ts,tsx}", "e2e/**/*.ts"]` blocks (one spreading `disableTypeChecked`, one turning off `consistent-type-assertions`) into a single block.
- **`app/routes/api.events.tsx`** — remove the dead `if (!properties || typeof properties !== "object")` guard in `sanitizeProperties`; the parameter type (`Record<string, unknown>`) plus the caller's upstream `isRecord` check already guarantee it.
- **`CLAUDE.md`** — split the dense ~90-word lockfile-hygiene bullet into sub-bullets to match the file's terse style.

## Deliberately not done

- **`server/app.ts` context-bridge test** — the reviewer suggested a regression test for the `{ ...context }` bridge. A clean one isn't worth it: passing a partial `Context` mock needs an `as`-cast (fighting the ban this stack just added) or a brittle full-`Context` fixture, and extracting a generic helper doesn't type-check (a generic spread isn't provably a `Record`). The inline comment already documents why the shallow spread is safe (Netlify's `Context` is a plain per-request object, not a prototype class).
- **Hook `${}` template interpolation / typegen-runs-twice** — both acknowledged as best-effort/harmless by the reviewer; ESLint remains the authoritative `as` check.

## Verification
- `npm run lint` ✓ · `npm run typecheck` ✓ · `npm run build` ✓ · `npm run test` ✓ (72)