### PR TITLE
fix(projects): match GitHub repos by database ID so all published projects render

### DIFF
--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -7,7 +7,7 @@ import type { loader as rootLoader } from "~/root";
 import { trackPageView } from "~/utils/analytics-loader";
 import { getCachedProjects } from "~/utils/contentful-cache";
 import { formatPostDate } from "~/utils/format-post-date";
-import { getRepositoriesByNodeId } from "~/utils/github";
+import { getRepositoriesByGhId, repoMatchesGhId } from "~/utils/github";
 
 import type { Route } from "./+types/index";
 
@@ -23,13 +23,15 @@ interface Repository {
 export async function loader() {
   async function getData() {
     const projects = await getCachedProjects();
-    const repos = await getRepositoriesByNodeId(
+    const repos = await getRepositoriesByGhId(
       projects
         .sort((a, b) => Number(a.fields.priority) - Number(b.fields.priority))
         .map((p) => p.fields.ghId),
     );
     const repositories: Repository[] = repos.map((repo) => {
-      const project = projects.find((p) => p.fields.ghId === repo.node_id);
+      const project = projects.find((p) =>
+        repoMatchesGhId(repo, p.fields.ghId),
+      );
       const screenshot =
         project?.fields.screenshot && "fields" in project.fields.screenshot
           ? project.fields.screenshot.fields.file?.url

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -139,7 +139,7 @@ export default function Index({ loaderData: repos }: Route.ComponentProps) {
             <Await resolve={repos} errorElement={<ProjectsError />}>
               {(resolvedRepos) => (
                 <div>
-                  {resolvedRepos.slice(0, 4).map((repo: Repository) => (
+                  {resolvedRepos.map((repo: Repository) => (
                     <ProjectRow
                       key={repo.id}
                       title={repo.name}

--- a/app/utils/github.test.ts
+++ b/app/utils/github.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { databaseIdFromGhId, repoMatchesGhId } from "./github";
+
+// A legacy GitHub global node ID base64-decodes to `010:Repository<databaseId>`.
+// `MDEwOlJlcG9zaXRvcnkxMjYzNTEzNDcw` -> `010:Repository1263513470`.
+const LEGACY_YNAB_MCP = "MDEwOlJlcG9zaXRvcnkxMjYzNTEzNDcw";
+const LEGACY_YNAB_MCP_DB_ID = 1263513470;
+
+// The new-format node ID GitHub now returns for that same repository.
+const NEW_YNAB_MCP = "R_kgDOS0-vfg";
+
+describe("databaseIdFromGhId", () => {
+  it("decodes a legacy node ID to its numeric database ID", () => {
+    expect(databaseIdFromGhId(LEGACY_YNAB_MCP)).toBe(LEGACY_YNAB_MCP_DB_ID);
+  });
+
+  it("passes a plain numeric string through as a database ID", () => {
+    expect(databaseIdFromGhId("1263513470")).toBe(1263513470);
+  });
+
+  it("returns null for a new-format node ID (not decodable to a database ID)", () => {
+    expect(databaseIdFromGhId(NEW_YNAB_MCP)).toBeNull();
+  });
+
+  it("returns null for values that don't decode to the legacy shape", () => {
+    expect(databaseIdFromGhId("not-base64!")).toBeNull();
+    expect(databaseIdFromGhId("")).toBeNull();
+  });
+});
+
+describe("repoMatchesGhId", () => {
+  it("matches a new-format repo to its legacy ghId via the database ID", () => {
+    // The regression this guards: the API now returns the new-format node_id,
+    // but Contentful still stores the legacy ghId. They must still match.
+    const repo = { id: LEGACY_YNAB_MCP_DB_ID, node_id: NEW_YNAB_MCP };
+    expect(repoMatchesGhId(repo, LEGACY_YNAB_MCP)).toBe(true);
+  });
+
+  it("matches when the legacy formats agree on both sides", () => {
+    const repo = { id: LEGACY_YNAB_MCP_DB_ID, node_id: LEGACY_YNAB_MCP };
+    expect(repoMatchesGhId(repo, LEGACY_YNAB_MCP)).toBe(true);
+  });
+
+  it("falls back to node_id when the ghId can't resolve to a database ID", () => {
+    const repo = { id: 1, node_id: NEW_YNAB_MCP };
+    expect(repoMatchesGhId(repo, NEW_YNAB_MCP)).toBe(true);
+  });
+
+  it("does not match unrelated repositories", () => {
+    const repo = { id: 999, node_id: "R_kgDOsomethingelse" };
+    expect(repoMatchesGhId(repo, LEGACY_YNAB_MCP)).toBe(false);
+  });
+});

--- a/app/utils/github.ts
+++ b/app/utils/github.ts
@@ -40,11 +40,38 @@ export const getAllRepositories = async () => {
   return data;
 };
 
-export const getRepositoriesByNodeId = async (nodeIds: string[]) => {
+// GitHub is migrating repositories from the legacy global node ID format
+// (base64 of `010:Repository<databaseId>`) to the new format (e.g. `R_kgDO…`).
+// The REST API returns whichever format applies to a given repo, so matching
+// purely on `node_id` silently drops any project whose stored ID no longer
+// matches what the API now returns. We match on the stable numeric database ID
+// instead, deriving it from the stored identifier when it's a legacy node ID.
+const LEGACY_NODE_ID_PREFIX = "010:Repository";
+
+function databaseIdFromGhId(ghId: string): number | null {
+  // A plain numeric string is already a database ID.
+  if (/^\d+$/.test(ghId)) return Number(ghId);
+
+  // Legacy node IDs base64-decode to `010:Repository<databaseId>`. New-format
+  // IDs (R_kgD…) don't decode to that shape — return null so the caller falls
+  // back to a direct node_id comparison for those.
+  const decoded = Buffer.from(ghId, "base64").toString("utf8");
+  if (!decoded.startsWith(LEGACY_NODE_ID_PREFIX)) return null;
+
+  const digits = decoded.slice(LEGACY_NODE_ID_PREFIX.length);
+  return /^\d+$/.test(digits) ? Number(digits) : null;
+}
+
+export const getRepositoriesByNodeId = async (ghIds: string[]) => {
   const repos = await getAllRepositories();
 
-  return nodeIds
-    .map((nodeId) => repos.find((repo) => repo.node_id === nodeId))
+  return ghIds
+    .map((ghId) => {
+      const databaseId = databaseIdFromGhId(ghId);
+      return repos.find((repo) =>
+        databaseId !== null ? repo.id === databaseId : repo.node_id === ghId,
+      );
+    })
     .filter((each) => each !== undefined);
 };
 

--- a/app/utils/github.ts
+++ b/app/utils/github.ts
@@ -48,7 +48,7 @@ export const getAllRepositories = async () => {
 // instead, deriving it from the stored identifier when it's a legacy node ID.
 const LEGACY_NODE_ID_PREFIX = "010:Repository";
 
-function databaseIdFromGhId(ghId: string): number | null {
+export function databaseIdFromGhId(ghId: string): number | null {
   // A plain numeric string is already a database ID.
   if (/^\d+$/.test(ghId)) return Number(ghId);
 
@@ -62,16 +62,26 @@ function databaseIdFromGhId(ghId: string): number | null {
   return /^\d+$/.test(digits) ? Number(digits) : null;
 }
 
-export const getRepositoriesByNodeId = async (ghIds: string[]) => {
+/**
+ * Whether a GitHub repo and a Contentful `ghId` refer to the same repository.
+ * Prefers the stable numeric database ID; falls back to a direct node_id
+ * comparison for identifiers we can't resolve to a database ID. Shared by both
+ * the repo lookup and any caller that needs to re-associate a repo with its
+ * Contentful entry, so the two never drift apart.
+ */
+export function repoMatchesGhId(
+  repo: { id: number; node_id: string },
+  ghId: string,
+): boolean {
+  const databaseId = databaseIdFromGhId(ghId);
+  return databaseId !== null ? repo.id === databaseId : repo.node_id === ghId;
+}
+
+export const getRepositoriesByGhId = async (ghIds: string[]) => {
   const repos = await getAllRepositories();
 
   return ghIds
-    .map((ghId) => {
-      const databaseId = databaseIdFromGhId(ghId);
-      return repos.find((repo) =>
-        databaseId !== null ? repo.id === databaseId : repo.node_id === ghId,
-      );
-    })
+    .map((ghId) => repos.find((repo) => repoMatchesGhId(repo, ghId)))
     .filter((each) => each !== undefined);
 };
 

--- a/docs/decisions/10_linting-formatting.md
+++ b/docs/decisions/10_linting-formatting.md
@@ -104,9 +104,7 @@ export default {
   semi: true,
   trailingComma: "all",
   singleQuote: false,
-  importOrder: [
-    /* ... */
-  ],
+  importOrder: [/* ... */],
   plugins: ["@trivago/prettier-plugin-sort-imports"],
 };
 ```


### PR DESCRIPTION
## Problem

Only 2 of my 5 published projects were rendering in the "Selected work" section on the homepage. The three missing ones (`ynab-mcp`, `bitbucket-mcp`, `atrium-site`) never appeared.

## Root cause

`getRepositoriesByNodeId` matched Contentful projects to GitHub repos purely on `node_id`. My Contentful `ghId` fields all store GitHub's **legacy** global node ID format (`010:Repository<databaseId>`, base64-encoded). GitHub has since migrated my newer repositories to the **new** node ID format (`R_kgDO…`), which is what the REST API now returns for them. The stored legacy IDs no longer matched the API response, so those projects were silently filtered out.

Verified against live data:

| Project (repo) | Stored `ghId` format | API returns | Matched? |
| --- | --- | --- | --- |
| card-games | legacy | legacy | ✅ |
| JimmyVanVeen.com | legacy | legacy | ✅ |
| ynab-mcp | legacy | `R_kgDOS0-vfg` | ❌ |
| bitbucket-mcp | legacy | `R_kgDORyrUCg` | ❌ |
| atrium-site | legacy | `R_kgDOStX-Cg` | ❌ |

Drafts were never involved — the production Contentful Delivery API already excludes unpublished entries.

## Fix

- Match repos on the **stable numeric database ID** instead of the mutable node-ID string, deriving it from the legacy node ID when needed and falling back to a direct `node_id` comparison otherwise. This is resilient to GitHub's ongoing node-ID migration.
- Remove the `slice(0, 4)` cap on the homepage so every published project is displayed.

## Verification

- Ran the app locally and inspected the rendered HTML: project rows went from **2 → 5** as the fix landed (all five now present).
- `npm run typecheck` clean; ESLint/oxlint/Prettier clean via pre-commit hooks.
- No `as` type assertions introduced.

## Follow-up (not in this PR)

The Contentful `ghId` fields still hold legacy node-ID strings. They're now matched safely by database ID, but migrating those fields to plain numeric IDs would be a worthwhile future cleanup.
