### PR TITLE
enhancement(lint): complete the as-ban project-wide (#381, #382)

### DIFF
--- a/app/routes/api.events.test.tsx
+++ b/app/routes/api.events.test.tsx
@@ -1,3 +1,5 @@
+import { fromPartial } from "@total-typescript/shoehorn";
+import { type RouterContextProvider } from "react-router";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { __resetForTesting, action } from "./api.events";
@@ -9,11 +11,13 @@ describe("Analytics API Route", () => {
 
     // Reset fetch mock
     vi.clearAllMocks();
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      text: async () => "",
-    } as Response);
+    global.fetch = vi.fn().mockResolvedValue(
+      fromPartial<Response>({
+        ok: true,
+        status: 200,
+        text: async () => "",
+      }),
+    );
   });
 
   const createMockRequest = (
@@ -39,7 +43,7 @@ describe("Analytics API Route", () => {
     url: new URL(request.url),
     pattern: "/api/events",
     params: {},
-    context: {} as never,
+    context: fromPartial<RouterContextProvider>({}),
   });
 
   describe("Request Validation", () => {
@@ -130,11 +134,13 @@ describe("Analytics API Route", () => {
 
   describe("Analytics API Errors", () => {
     it("should handle API errors gracefully", async () => {
-      global.fetch = vi.fn().mockResolvedValue({
-        ok: false,
-        status: 500,
-        text: async () => "Analytics Server Error",
-      } as Response);
+      global.fetch = vi.fn().mockResolvedValue(
+        fromPartial<Response>({
+          ok: false,
+          status: 500,
+          text: async () => "Analytics Server Error",
+        }),
+      );
 
       const request = createMockRequest("POST", {
         event: "page_view",

--- a/app/utils/analytics-loader.test.ts
+++ b/app/utils/analytics-loader.test.ts
@@ -1,3 +1,4 @@
+import { fromPartial } from "@total-typescript/shoehorn";
 // Import types for proper mocking
 import type { ClientLoaderFunctionArgs } from "react-router";
 
@@ -260,9 +261,9 @@ describe("Analytics Loader", () => {
 
       const { withServerLoaderAnalytics } = await import("./analytics-loader");
 
-      const args = {
+      const args = fromPartial<ClientLoaderFunctionArgs>({
         serverLoader: mockServerLoader,
-      } as unknown as ClientLoaderFunctionArgs;
+      });
 
       const result = await withServerLoaderAnalytics(args);
 
@@ -300,9 +301,9 @@ describe("Analytics Loader", () => {
 
       const { withServerLoaderAnalytics } = await import("./analytics-loader");
 
-      const args = {
+      const args = fromPartial<ClientLoaderFunctionArgs>({
         serverLoader: mockServerLoader,
-      } as unknown as ClientLoaderFunctionArgs;
+      });
 
       // Should return server loader result even if analytics fails
       const result = await withServerLoaderAnalytics(args);
@@ -445,9 +446,9 @@ describe("Analytics Loader", () => {
       const { withAnalytics } = await import("./analytics-loader");
       const clientLoader = withAnalytics();
 
-      const args = {
+      const args = fromPartial<ClientLoaderFunctionArgs>({
         serverLoader: mockServerLoader,
-      } as unknown as ClientLoaderFunctionArgs;
+      });
 
       const result = await clientLoader(args);
 

--- a/app/utils/analytics.client.test.ts
+++ b/app/utils/analytics.client.test.ts
@@ -1,3 +1,5 @@
+import { fetchBody } from "../../config/test/mock-fetch";
+import { fromPartial } from "@total-typescript/shoehorn";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { analytics } from "./analytics.client";
@@ -19,11 +21,13 @@ describe("Analytics Client", () => {
 
     // Reset fetch mock
     vi.clearAllMocks();
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => ({ success: true }),
-    } as Response);
+    global.fetch = vi.fn().mockResolvedValue(
+      fromPartial<Response>({
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true }),
+      }),
+    );
 
     // Mock document and window properties
     Object.defineProperty(document, "title", {
@@ -52,8 +56,7 @@ describe("Analytics Client", () => {
     it("should track page views with default path", async () => {
       await analytics.page();
 
-      const callArgs = (fetch as ReturnType<typeof vi.fn>).mock.calls[0]!;
-      const payload = JSON.parse(callArgs[1].body);
+      const payload = fetchBody(0);
 
       expect(payload.event).toBe("page_view");
       expect(payload.properties.page_path).toBe("/page");
@@ -63,8 +66,7 @@ describe("Analytics Client", () => {
     it("should track page views with custom path", async () => {
       await analytics.page("/custom-page", { utm_source: "test" });
 
-      const callArgs = (fetch as ReturnType<typeof vi.fn>).mock.calls[0]!;
-      const payload = JSON.parse(callArgs[1].body);
+      const payload = fetchBody(0);
 
       expect(payload.event).toBe("page_view");
       expect(payload.properties.page_path).toBe("/custom-page");
@@ -97,10 +99,12 @@ describe("Analytics Client", () => {
     });
 
     it("should handle server errors gracefully", async () => {
-      global.fetch = vi.fn().mockResolvedValue({
-        ok: false,
-        status: 500,
-      } as Response);
+      global.fetch = vi.fn().mockResolvedValue(
+        fromPartial<Response>({
+          ok: false,
+          status: 500,
+        }),
+      );
 
       // Should not throw error
       await expect(analytics.page()).resolves.toBeUndefined();
@@ -110,8 +114,8 @@ describe("Analytics Client", () => {
       await analytics.page("/page1");
       await analytics.page("/page2");
 
-      const call1 = JSON.parse((fetch as ReturnType<typeof vi.fn>).mock.calls[0]![1].body);
-      const call2 = JSON.parse((fetch as ReturnType<typeof vi.fn>).mock.calls[1]![1].body);
+      const call1 = fetchBody(0);
+      const call2 = fetchBody(1);
 
       expect(call1.properties.client_id).toBeDefined();
       expect(call2.properties.client_id).toBeDefined();

--- a/app/utils/analytics/providers/goatcounter.test.ts
+++ b/app/utils/analytics/providers/goatcounter.test.ts
@@ -1,3 +1,5 @@
+import { fetchBody } from "../../../../config/test/mock-fetch";
+import { fromPartial } from "@total-typescript/shoehorn";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AnalyticsEvent, PageViewData } from "../types";
@@ -17,11 +19,13 @@ describe("GoatCounter Provider", () => {
   beforeEach(() => {
     provider = new GoatCounterProvider();
     vi.clearAllMocks();
-    global.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      text: async () => "",
-    } as Response);
+    global.fetch = vi.fn().mockResolvedValue(
+      fromPartial<Response>({
+        ok: true,
+        status: 200,
+        text: async () => "",
+      }),
+    );
   });
 
   describe("Initialization", () => {
@@ -107,8 +111,7 @@ describe("GoatCounter Provider", () => {
         }),
       );
 
-      const callArgs = (fetch as ReturnType<typeof vi.fn>).mock.calls[0]!;
-      const payload = JSON.parse(callArgs[1].body);
+      const payload = fetchBody(0);
 
       expect(payload.hits).toHaveLength(1);
       expect(payload.hits[0]).toMatchObject({
@@ -141,11 +144,13 @@ describe("GoatCounter Provider", () => {
     });
 
     it("should handle API errors gracefully", async () => {
-      global.fetch = vi.fn().mockResolvedValue({
-        ok: false,
-        status: 500,
-        text: async () => "Internal Server Error",
-      } as Response);
+      global.fetch = vi.fn().mockResolvedValue(
+        fromPartial<Response>({
+          ok: false,
+          status: 500,
+          text: async () => "Internal Server Error",
+        }),
+      );
 
       const pageData: PageViewData = {
         path: "/test",
@@ -169,8 +174,7 @@ describe("GoatCounter Provider", () => {
 
       await provider.trackPageView(pageData);
 
-      const callArgs = (fetch as ReturnType<typeof vi.fn>).mock.calls[0]!;
-      const payload = JSON.parse(callArgs[1].body);
+      const payload = fetchBody(0);
 
       expect(payload.hits[0].ref).toBe("https://www.google.com/search");
     });
@@ -197,8 +201,7 @@ describe("GoatCounter Provider", () => {
 
       expect(fetch).toHaveBeenCalled();
 
-      const callArgs = (fetch as ReturnType<typeof vi.fn>).mock.calls[0]!;
-      const payload = JSON.parse(callArgs[1].body);
+      const payload = fetchBody(0);
 
       expect(payload.hits[0]).toMatchObject({
         path: "/blog/post",
@@ -232,8 +235,7 @@ describe("GoatCounter Provider", () => {
 
       expect(fetch).toHaveBeenCalled();
 
-      const callArgs = (fetch as ReturnType<typeof vi.fn>).mock.calls[0]!;
-      const payload = JSON.parse(callArgs[1].body);
+      const payload = fetchBody(0);
 
       expect(payload.hits[0].path).toBe("/minimal");
     });

--- a/app/utils/contentful-cache.test.ts
+++ b/app/utils/contentful-cache.test.ts
@@ -1,0 +1,95 @@
+import { fromPartial } from "@total-typescript/shoehorn";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the Contentful fetchers so we can assert whether a cache miss or a
+// validation fall-through actually triggers a fresh fetch.
+vi.mock("./contentful", () => ({
+  getProjects: vi.fn(),
+  getAllBlogPosts: vi.fn(),
+  getBlogPostBySlug: vi.fn(),
+}));
+
+// Mock the Netlify Blobs store. In the test env `NODE_ENV` is "test" (not
+// "development"), so `getCachedData` takes the Netlify Blobs branch and reads
+// through `getWithMetadata`.
+const getWithMetadata = vi.fn();
+const setJSON = vi.fn();
+vi.mock("@netlify/blobs", () => ({
+  getStore: vi.fn(() => ({
+    getWithMetadata,
+    setJSON,
+    list: vi.fn(),
+    delete: vi.fn(),
+    getMetadata: vi.fn(),
+  })),
+}));
+
+import * as contentful from "./contentful";
+import { getCachedProjects } from "./contentful-cache";
+
+type Projects = Awaited<ReturnType<typeof contentful.getProjects>>;
+
+describe("contentful-cache validation guards", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the cached value when the blob is a fresh, well-typed array", async () => {
+    const cached: Projects = fromPartial([{}]);
+    getWithMetadata.mockResolvedValue({ data: { data: cached, timestamp: Date.now() } });
+
+    const result = await getCachedProjects();
+
+    expect(result).toBe(cached);
+    expect(contentful.getProjects).not.toHaveBeenCalled();
+  });
+
+  it("refetches when the cached payload fails the type guard (not an array)", async () => {
+    const fresh: Projects = fromPartial([{}]);
+    vi.mocked(contentful.getProjects).mockResolvedValue(fresh);
+    // `data` is an object, not an array — `isProjects` (Array.isArray) rejects it.
+    getWithMetadata.mockResolvedValue({
+      data: { data: { not: "an array" }, timestamp: Date.now() },
+    });
+
+    const result = await getCachedProjects();
+
+    expect(contentful.getProjects).toHaveBeenCalledOnce();
+    expect(result).toBe(fresh);
+  });
+
+  it("refetches when the cache-entry wrapper is malformed (no timestamp)", async () => {
+    const fresh: Projects = fromPartial([{}]);
+    vi.mocked(contentful.getProjects).mockResolvedValue(fresh);
+    // Missing `timestamp` — `isCacheEntry` rejects the wrapper entirely.
+    getWithMetadata.mockResolvedValue({ data: { data: [{ id: "stale" }] } });
+
+    const result = await getCachedProjects();
+
+    expect(contentful.getProjects).toHaveBeenCalledOnce();
+    expect(result).toBe(fresh);
+  });
+
+  it("refetches when the cached entry is expired", async () => {
+    const fresh: Projects = fromPartial([{}]);
+    vi.mocked(contentful.getProjects).mockResolvedValue(fresh);
+    // timestamp epoch 0 — age far exceeds the TTL.
+    getWithMetadata.mockResolvedValue({ data: { data: [{ id: "old" }], timestamp: 0 } });
+
+    const result = await getCachedProjects();
+
+    expect(contentful.getProjects).toHaveBeenCalledOnce();
+    expect(result).toBe(fresh);
+  });
+
+  it("refetches when the blob store has no cached entry", async () => {
+    const fresh: Projects = fromPartial([{}]);
+    vi.mocked(contentful.getProjects).mockResolvedValue(fresh);
+    getWithMetadata.mockResolvedValue(null);
+
+    const result = await getCachedProjects();
+
+    expect(contentful.getProjects).toHaveBeenCalledOnce();
+    expect(result).toBe(fresh);
+  });
+});

--- a/app/utils/contentful-cache.ts
+++ b/app/utils/contentful-cache.ts
@@ -1,6 +1,7 @@
 import { getStore } from "@netlify/blobs";
 
 import * as contentful from "./contentful";
+import { isRecord } from "./is-record";
 
 interface CacheEntry<T> {
   data: T;
@@ -12,6 +13,25 @@ interface CacheConfig {
   ttl: number;
   store: string;
 }
+
+// A cached value's runtime type is erased once it round-trips through JSON /
+// Netlify Blobs, so reads validate the wrapper shape with this guard and the
+// payload with a caller-supplied `isValid` predicate — no `as` assertion.
+function isCacheEntry(value: unknown): value is CacheEntry<unknown> {
+  return isRecord(value) && "data" in value && typeof value["timestamp"] === "number";
+}
+
+type Guard<T> = (value: unknown) => value is T;
+
+// Shallow type guards for the cached payloads. The predicate return type is a
+// deliberate contract (the Contentful shape is validated at fetch time), which
+// is the sanctioned alternative to an `as` assertion for erased runtime types.
+type Projects = Awaited<ReturnType<typeof contentful.getProjects>>;
+type BlogPosts = Awaited<ReturnType<typeof contentful.getAllBlogPosts>>;
+type BlogPost = Awaited<ReturnType<typeof contentful.getBlogPostBySlug>>;
+const isProjects = (value: unknown): value is Projects => Array.isArray(value);
+const isBlogPosts = (value: unknown): value is BlogPosts => Array.isArray(value);
+const isBlogPost = (value: unknown): value is BlogPost => isRecord(value);
 
 const isDevelopment = process.env["NODE_ENV"] === "development";
 const isNetlifyBuild = process.env["NETLIFY"] === "true";
@@ -57,10 +77,11 @@ async function getCachedData<T>(
   key: string,
   config: CacheConfig,
   fetcher: () => Promise<T>,
+  isValid: Guard<T>,
 ): Promise<T> {
   // Use in-memory cache for development if Netlify Blobs not configured
   if (isDevelopment && !hasNetlifyBlobsConfig) {
-    return getCachedDataMemory(key, config, fetcher);
+    return getCachedDataMemory(key, config, fetcher, isValid);
   }
 
   // Use Netlify Blobs for production or if configured
@@ -70,13 +91,13 @@ async function getCachedData<T>(
     // Try to get cached data with metadata
     const cached = await store.getWithMetadata(key, { type: "json" });
 
-    if (cached?.data) {
-      const entry = cached.data as CacheEntry<T>;
+    if (isCacheEntry(cached?.data)) {
+      const entry = cached.data;
       const now = Date.now();
       const age = now - entry.timestamp;
 
-      // Return cached data if still fresh
-      if (age < config.ttl) {
+      // Return cached data if still fresh and the payload matches its type
+      if (age < config.ttl && isValid(entry.data)) {
         console.log(
           `[Cache HIT] ${key} (age: ${Math.round(age / 1000)}s, ttl: ${config.ttl / 1000}s)`,
         );
@@ -123,6 +144,7 @@ async function getCachedDataMemory<T>(
   key: string,
   config: CacheConfig,
   fetcher: () => Promise<T>,
+  isValid: Guard<T>,
 ): Promise<T> {
   // Check memory cache
   const cached = memoryCache.get(key);
@@ -131,12 +153,12 @@ async function getCachedDataMemory<T>(
     const now = Date.now();
     const age = now - cached.timestamp;
 
-    // Return cached data if still fresh
-    if (age < config.ttl) {
+    // Return cached data if still fresh and the payload matches its type
+    if (age < config.ttl && isValid(cached.data)) {
       console.log(
         `[Memory Cache HIT] ${key} (age: ${Math.round(age / 1000)}s, ttl: ${config.ttl / 1000}s)`,
       );
-      return cached.data as T;
+      return cached.data;
     }
 
     console.log(
@@ -179,7 +201,7 @@ export async function getCachedProjects() {
   }
 
   // Otherwise use normal caching behavior
-  return getCachedData("all-projects", CACHE_CONFIG.projects, contentful.getProjects);
+  return getCachedData("all-projects", CACHE_CONFIG.projects, contentful.getProjects, isProjects);
 }
 
 /**
@@ -202,7 +224,12 @@ export async function getCachedBlogPosts() {
   }
 
   // Otherwise use normal caching behavior
-  return getCachedData("all-blog-posts", CACHE_CONFIG.blogPosts, contentful.getAllBlogPosts);
+  return getCachedData(
+    "all-blog-posts",
+    CACHE_CONFIG.blogPosts,
+    contentful.getAllBlogPosts,
+    isBlogPosts,
+  );
 }
 
 /**
@@ -224,8 +251,11 @@ export async function getCachedBlogPostBySlug(slug: string) {
   }
 
   // Otherwise use normal caching behavior
-  return getCachedData(`blog-post-${slug}`, CACHE_CONFIG.blogPost, () =>
-    contentful.getBlogPostBySlug(slug),
+  return getCachedData(
+    `blog-post-${slug}`,
+    CACHE_CONFIG.blogPost,
+    () => contentful.getBlogPostBySlug(slug),
+    isBlogPost,
   );
 }
 

--- a/config/oxlintrc.json
+++ b/config/oxlintrc.json
@@ -63,10 +63,8 @@
       }
     },
     {
-      "files": ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/e2e/**"],
+      "files": ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/e2e/**", "config/test/**"],
       "rules": {
-        "typescript/consistent-type-assertions": "off",
-        "typescript/no-unsafe-type-assertion": "off",
         "typescript/no-unnecessary-type-assertion": "off",
         "typescript/await-thenable": "off",
         "typescript/no-floating-promises": "off",
@@ -80,13 +78,6 @@
         "typescript/no-unsafe-return": "off",
         "typescript/no-base-to-string": "off",
         "typescript/unbound-method": "off"
-      }
-    },
-    {
-      "files": ["**/contentful-cache.ts"],
-      "rules": {
-        "typescript/consistent-type-assertions": "off",
-        "typescript/no-unsafe-type-assertion": "off"
       }
     }
   ],

--- a/config/test/mock-fetch.ts
+++ b/config/test/mock-fetch.ts
@@ -1,0 +1,15 @@
+import { vi } from "vitest";
+
+/**
+ * Test helper: JSON-parse the request body of the Nth global `fetch` mock call.
+ * `vi.mocked(fetch)` gives a precisely-typed body (`BodyInit | null | undefined`),
+ * so this narrows to a string at runtime instead of asserting — then returns the
+ * parsed payload for specs to read arbitrary fields from.
+ */
+export function fetchBody(index: number) {
+  const body = vi.mocked(fetch).mock.calls[index]?.[1]?.body;
+  if (typeof body !== "string") {
+    throw new Error(`fetch mock call #${index} had no string body`);
+  }
+  return JSON.parse(body);
+}

--- a/e2e/analytics.spec.ts
+++ b/e2e/analytics.spec.ts
@@ -51,7 +51,7 @@ test.describe("Analytics E2E Tests", () => {
       const postData = request.postDataJSON();
 
       if (postData?.properties?.client_id) {
-        clientIds.push(postData.properties.client_id as string);
+        clientIds.push(String(postData.properties.client_id));
       }
 
       await route.fulfill({
@@ -83,7 +83,7 @@ test.describe("Analytics E2E Tests", () => {
       const postData = request.postDataJSON();
 
       if (postData?.event === "page_view") {
-        capturedEvent = postData as Record<string, unknown>;
+        capturedEvent = postData;
       }
 
       await route.fulfill({
@@ -202,7 +202,7 @@ test.describe("Analytics E2E Tests", () => {
       const postData = request.postDataJSON();
 
       if (postData?.properties?.client_id) {
-        clientId = postData.properties.client_id as string;
+        clientId = String(postData.properties.client_id);
       }
 
       await route.fulfill({
@@ -250,7 +250,7 @@ test.describe("Analytics E2E Tests", () => {
       const postData = request.postDataJSON();
 
       if (postData?.event === "page_view" && postData?.properties?.page_path) {
-        pageViews.push(postData.properties.page_path as string);
+        pageViews.push(String(postData.properties.page_path));
       }
 
       await route.fulfill({

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
+        "@total-typescript/shoehorn": "^0.1.2",
         "@types/node": "^22.20.1",
         "@types/nodemailer": "^8.0.0",
         "@types/react": "^19.2.17",
@@ -6694,6 +6695,13 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@total-typescript/shoehorn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@total-typescript/shoehorn/-/shoehorn-0.1.2.tgz",
+      "integrity": "sha512-p7nNZbOZIofpDNyP0u1BctFbjxD44Qc+oO5jufgQdFdGIXJLc33QRloJpq7k5T59CTgLWfQSUxsuqLcmeurYRw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
@@ -6860,6 +6868,7 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -7065,6 +7074,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7081,6 +7091,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7097,6 +7108,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7113,6 +7125,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7129,6 +7142,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7145,6 +7159,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7161,6 +7176,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7177,6 +7193,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7193,6 +7210,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7209,6 +7227,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7225,6 +7244,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7241,6 +7261,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7257,6 +7278,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7273,6 +7295,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7289,6 +7312,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7305,6 +7329,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7321,6 +7346,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7337,6 +7363,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7353,6 +7380,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -7369,6 +7397,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -9618,6 +9647,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-color": {
@@ -22051,7 +22081,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
       "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
+    "@total-typescript/shoehorn": "^0.1.2",
     "@types/node": "^22.20.1",
     "@types/nodemailer": "^8.0.0",
     "@types/react": "^19.2.17",


### PR DESCRIPTION
Completes the project-wide `as` ban that the toolchain modernization (#405) deferred — the last two oxlint exemptions are now gone, so **zero `as` assertions remain anywhere** (the only ` as ` left is an `import { Prism as … }` alias).

## Tests (#381)
Every test/e2e `as` migrated to a sanctioned alternative:
- `(fetch as ReturnType<typeof vi.fn>)` → **`vi.mocked(fetch)`**
- partial `Response` / `ClientLoaderFunctionArgs` mocks → **`fromPartial<T>()`** (`@total-typescript/shoehorn`)
- `context: {} as never` → **`new RouterContextProvider()`** shape via `fromPartial`
- e2e `any`-typed reads → **`String(...)`**
- a small **`fetchBody()`** test helper narrows the now-precisely-typed mock body (a real win of `vi.mocked` over the old `any` cast)

## contentful-cache.ts (#382)
`cached.data as CacheEntry<T>` / `as T` replaced with an **`isCacheEntry` wrapper guard** + **caller-supplied type guards** (`isProjects`/`isBlogPosts`/`isBlogPost`) — validating the erased runtime type at the boundary, exactly as CLAUDE.md prescribes.

The oxlint test override now only silences the *any-flow* rules (`no-unsafe-*`) since mock values are inherently `any`; the `as`-assertion carve-outs are removed.

Verified green (Node 24): oxlint, oxfmt, typecheck, 80 tests, build.

Closes #381. Closes #382.
