### PR TITLE
ci(e2e): run Playwright on PRs against a production build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,10 @@ jobs:
     # Runs on PRs as well as main: Playwright drives a local production build
     # (see playwright.config.ts webServer), so it needs no deploy preview and
     # stays deterministic. Catching E2E regressions pre-merge is the point.
+    #
+    # `needs: build` is a fast-fail gate, not an artifact hand-off — Playwright
+    # rebuilds in-job (~2s) with the E2E env applied, so a broken build fails in
+    # the cheap job before this one spends its 15-minute budget.
     needs: build
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,8 +92,9 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # Only run E2E tests on main branch, not on PRs
-    if: github.ref == 'refs/heads/main'
+    # Runs on PRs as well as main: Playwright drives a local production build
+    # (see playwright.config.ts webServer), so it needs no deploy preview and
+    # stays deterministic. Catching E2E regressions pre-merge is the point.
     needs: build
 
     steps:
@@ -112,12 +113,16 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
+      # The build/serve env (DISABLE_CONTENTFUL_RUNTIME, JVV_*, …) lives in
+      # playwright.config.ts `webServer.env` rather than here, so running
+      # `npm run test:e2e` locally is identical to running it in CI.
       - name: Run Playwright E2E tests
         run: npm run test:e2e
-        env:
-          # Disable external API calls during E2E tests
-          DISABLE_CONTENTFUL_RUNTIME: true
-          DISABLE_GITHUB_INTEGRATION: true
-          # Provide test values for required environment variables
-          JVV_ALLOW_EMAILS: false
-          JVV_RECAPTCHA_SITE_KEY: test-key
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,12 @@
 /.react-router/
 /build/
 
+# Playwright output (report + traces/screenshots from failed runs)
+/playwright-report/
+/test-results/
+/blob-report/
+/playwright/.cache/
+
 # Local env files
 .env
 

--- a/docs/decisions/13_oxc-toolchain-modernization.md
+++ b/docs/decisions/13_oxc-toolchain-modernization.md
@@ -3,10 +3,10 @@
 ## Status
 
 Accepted (built and merged 2026-07-24). The **Decision** section below records the
-original plan; see **As-built deviations** for what actually shipped (npm 11,
-`pedantic` off, E2E-on-PR deferred). Two initial deviations have since been closed
-out: the preview pins are now on stable (#415) and the test `as` exemption is gone
-(#416), so the `as` ban is project-wide.
+original plan; see **As-built deviations** for what actually shipped (npm 11 and
+`pedantic` off are the two that remain). The other three deviations have since been
+closed out: the preview pins are on stable (#415), the test `as` exemption is gone
+(#416) so the `as` ban is project-wide, and E2E now runs on every PR.
 
 Supersedes **ADR 10 (ESLint & Prettier)**. Amends **ADR 01 (TypeScript)** and
 **ADR 12 (GitHub Actions CI/CD)**.
@@ -30,8 +30,14 @@ Supersedes **ADR 10 (ESLint & Prettier)**. Amends **ADR 01 (TypeScript)** and
   zero assertions in production _or_ test code.
 - RR8 needed `--legacy-peer-deps` (framework major bump) and a `server/app.ts`
   RouterContextProvider + server-build boundary fix.
-- **E2E-on-PR (item 8b) deferred** — the Playwright `test-e2e` job stays gated to
-  `main` for now; running it on PRs against the deploy preview is a fast-follow.
+- ~~**E2E-on-PR (item 8b) deferred**~~ **RESOLVED** — `test-e2e` no longer gates on
+  `main`; it runs on every PR. It drives a **local production build** via
+  `react-router-serve` (see `playwright.config.ts` `webServer`) rather than the
+  Netlify deploy preview: same pre-merge signal, but deterministic and with no
+  wait-for-Netlify step, third-party action, or extra secrets. This also fixed E2E
+  previously running against the Vite **dev** server, which is not the artifact
+  that ships. Trade-off accepted: Netlify-specific SSR/Functions behaviour is still
+  only exercised post-merge.
 
 ## Context
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -41,11 +41,26 @@ export default defineConfig({
     },
   ],
 
-  /* Run your local dev server before starting the tests */
+  /* Build and serve the PRODUCTION bundle before starting the tests.
+   *
+   * These specs gate every PR, so they must exercise the artifact that actually
+   * ships — not the Vite dev server, which differs in bundling, SSR entry, and
+   * env handling. `react-router-serve` runs the same `build/server/index.js`
+   * the deploy consumes. The build is only a couple of seconds, so rebuilding
+   * per run is cheaper than reasoning about a stale `build/`.
+   */
   webServer: {
-    command: "npm run dev",
+    command: "npm run build && react-router-serve ./build/server/index.js",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env["CI"],
     timeout: 120000,
+    /* Keep external APIs out of E2E: Contentful/GitHub are stubbed off, and the
+     * JVV_* vars must be present at BUILD time since they inline into the client. */
+    env: {
+      DISABLE_CONTENTFUL_RUNTIME: "true",
+      DISABLE_GITHUB_INTEGRATION: "true",
+      JVV_ALLOW_EMAILS: "false",
+      JVV_RECAPTCHA_SITE_KEY: "test-key",
+    },
   },
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -52,7 +52,11 @@ export default defineConfig({
   webServer: {
     command: "npm run build && react-router-serve ./build/server/index.js",
     url: "http://localhost:3000",
-    reuseExistingServer: !process.env["CI"],
+    /* Never reuse a server already on :3000. Reusing would silently hand the
+     * suite a `npm run dev` process — the dev server this config exists to stop
+     * testing against. Failing loudly with "port already used" is the point:
+     * stop your dev server before running e2e locally. */
+    reuseExistingServer: false,
     timeout: 120000,
     /* Keep external APIs out of E2E: Contentful/GitHub are stubbed off, and the
      * JVV_* vars must be present at BUILD time since they inline into the client. */


### PR DESCRIPTION
Closes out **ADR 13 item 8b**, the last deferred piece of the toolchain modernization (#405).

## Problem

E2E was gated to `main` only (`if: github.ref == 'refs/heads/main'`), so a PR could go fully green and still break E2E after merge — the exact post-merge surprise the modernization set out to eliminate.

Separately, the E2E job was driving `npm run dev` — the **Vite dev server**, which differs from the shipped artifact in bundling, SSR entry, and env handling. So E2E was never actually exercising a production build.

## Change

**1. Playwright now builds and serves the production bundle.** `webServer` runs `npm run build && react-router-serve ./build/server/index.js` — the same `build/server/index.js` the deploy consumes. `@react-router/serve` was already a dependency, so no new deps. The build takes ~2s, so rebuilding per run is cheaper than reasoning about a stale `build/`.

**2. Drops the `main`-only gate**, so E2E runs on every PR.

I went with a local production build rather than the Netlify deploy preview (the option ADR 13 originally floated). Same pre-merge signal, but deterministic: no wait-for-Netlify step, no third-party action, no extra secrets, and no dependency on deploy timing. The accepted trade-off is that Netlify-specific SSR/Functions behaviour is still only exercised post-merge — noted explicitly in the ADR.

**3. Build/serve env moved into `playwright.config.ts` `webServer.env`** (out of the workflow step), so `npm run test:e2e` behaves identically locally and in CI. That's ADR 13's "green local structurally means green CI" goal.

**4. Uploads the Playwright HTML report as an artifact on failure** — an E2E failure now blocks a PR, so it has to be debuggable without a local repro.

**5. Gitignores Playwright output** (`playwright-report/`, `test-results/`, `blob-report/`, `playwright/.cache/`), which was never ignored and would otherwise get committed by a stray `git add -A`.

## Verification

Run locally on the pinned toolchain (Node 24.18.0 / npm 11.16.0):

- **`CI=1 npm run test:e2e` against a clean `build/` — 9/9 passed (21.3s).** This is the real check: `CI=1` disables `reuseExistingServer`, so Playwright did a cold build + serve exactly as the runner will.
- `npm run lint` — 3 diagnostics, identical to `main` (pre-existing `nursery`-tier warnings)
- `npm run typecheck` — 0 errors
- `npm run format:check` — clean
- `npx vitest run` — 85 passed

One note for the log: the E2E run emits `MissingBlobsEnvironmentError` warnings from `contentful-cache`. Those are the caught fallback path (cache miss → refetch), not failures, and are pre-existing behaviour — `DISABLE_CONTENTFUL_RUNTIME` only short-circuits when build-time data is present in the same process, which it isn't for a fresh server. Left alone here as out of scope.



---

**Correction (post-review):** an earlier version of this description said `@react-router/serve` was a *devDependency*; it is in `dependencies`. It was already installed either way, so the change itself is unaffected.

**Follow-up filed:** #419 — while verifying this PR I hit an intermittent failure in the DNT spec under the local 8-worker default (1 failure in 3 full-suite runs; 5/5 stable at `--workers=1`). CI pins `workers: 1` + `retries: 2` and is green, so this PR is not blocked, but the flake is now tracked rather than left to surface later as a random PR re-run.
